### PR TITLE
feat: RBAC — role-based access control integrated with Databricks workspace identity

### DIFF
--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -24,19 +24,6 @@ gateway_router = APIRouter()
 settings = get_settings()
 
 
-def _get_token(req: Request) -> str:
-    """Extract bearer token from request headers."""
-    token = req.headers.get("X-Forwarded-Access-Token")
-    if not token:
-        auth = req.headers.get("Authorization", "")
-        if auth.startswith("Bearer "):
-            token = auth[7:]
-    if not token:
-        token = get_effective_setting("lakebase_service_token") or settings.databricks_token
-    if not token:
-        raise HTTPException(status_code=401, detail="No authentication token available")
-    return token
-
 
 async def _require_role(req: Request, min_role: str):
     """Resolve caller's effective role and raise 403 if below min_role.
@@ -276,7 +263,7 @@ async def get_gateway_logs(gateway_id: str, limit: int = 50):
 async def list_genie_spaces(req: Request):
     """List available Genie Spaces from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/genie/spaces"
@@ -300,7 +287,7 @@ async def list_genie_spaces(req: Request):
 async def list_warehouses(req: Request):
     """List available SQL warehouses from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/sql/warehouses"
@@ -324,7 +311,7 @@ async def list_warehouses(req: Request):
 async def list_serving_endpoints(req: Request):
     """List available serving endpoints from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/serving-endpoints"

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -11,7 +11,9 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 
+from app.auth import ensure_https
 from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
+from app.api.auth_helpers import extract_bearer_token
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
@@ -37,8 +39,10 @@ def _get_token(req: Request) -> str:
 
 
 async def _require_role(req: Request, min_role: str):
-    """Resolve caller's effective role and raise 403 if below min_role."""
-    token = _get_token(req)
+    """Resolve caller's effective role and raise 403 if below min_role.
+    Uses extract_bearer_token (user OBO token only — no service-token fallback).
+    """
+    token = extract_bearer_token(req)
     identity = req.headers.get("X-Forwarded-Email", "")
     host = _get_host()
     role = await resolve_role(identity, token, host)
@@ -54,9 +58,7 @@ def _get_host() -> str:
     host = get_effective_setting("databricks_host") or settings.databricks_host
     if not host:
         raise HTTPException(status_code=500, detail="DATABRICKS_HOST not configured")
-    if not host.startswith("http"):
-        host = f"https://{host}"
-    return host
+    return ensure_https(host)
 
 
 # --- Gateway CRUD ---

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -15,6 +15,7 @@ from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
+from app.services.rbac import resolve_role, role_gte
 
 logger = logging.getLogger(__name__)
 gateway_router = APIRouter()
@@ -33,6 +34,19 @@ def _get_token(req: Request) -> str:
     if not token:
         raise HTTPException(status_code=401, detail="No authentication token available")
     return token
+
+
+async def _require_role(req: Request, min_role: str):
+    """Resolve caller's effective role and raise 403 if below min_role."""
+    token = _get_token(req)
+    identity = req.headers.get("X-Forwarded-Email", "")
+    host = _get_host()
+    role = await resolve_role(identity, token, host)
+    if not role_gte(role, min_role):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{min_role}' required. You have '{role}'."
+        )
 
 
 def _get_host() -> str:
@@ -69,7 +83,8 @@ async def list_gateways():
 
 @gateway_router.post("/gateways", status_code=201)
 async def create_gateway(body: GatewayCreateRequest, req: Request):
-    """Create a new gateway configuration."""
+    """Create a new gateway configuration. Owner only."""
+    await _require_role(req, "owner")
     try:
         now = datetime.now(timezone.utc)
         user_email = req.headers.get("X-Forwarded-Email")
@@ -132,8 +147,9 @@ async def get_gateway(gateway_id: str):
 
 
 @gateway_router.put("/gateways/{gateway_id}")
-async def update_gateway(gateway_id: str, body: GatewayUpdateRequest):
-    """Update gateway fields."""
+async def update_gateway(gateway_id: str, body: GatewayUpdateRequest, req: Request):
+    """Update gateway fields. Manage or above."""
+    await _require_role(req, "manage")
     try:
         updates = body.model_dump(exclude_none=True)
         if not updates:
@@ -153,8 +169,9 @@ async def update_gateway(gateway_id: str, body: GatewayUpdateRequest):
 
 
 @gateway_router.delete("/gateways/{gateway_id}")
-async def delete_gateway(gateway_id: str):
-    """Delete a gateway."""
+async def delete_gateway(gateway_id: str, req: Request):
+    """Delete a gateway. Owner only."""
+    await _require_role(req, "owner")
     try:
         deleted = await _db.db_service.delete_gateway(gateway_id)
         if not deleted:
@@ -218,8 +235,9 @@ async def get_gateway_cache(gateway_id: str):
 
 
 @gateway_router.delete("/gateways/{gateway_id}/cache")
-async def clear_gateway_cache(gateway_id: str):
-    """Clear all cached entries for a specific gateway."""
+async def clear_gateway_cache(gateway_id: str, req: Request):
+    """Clear all cached entries for a specific gateway. Manage or above."""
+    await _require_role(req, "manage")
     try:
         gw = await _db.db_service.get_gateway(gateway_id)
         if not gw:
@@ -439,8 +457,9 @@ class SettingsUpdateRequest(GatewayUpdateRequest):
 
 
 @gateway_router.put("/settings")
-async def update_settings_endpoint(body: SettingsUpdateRequest):
-    """Update server configuration."""
+async def update_settings_endpoint(body: SettingsUpdateRequest, req: Request):
+    """Update server configuration. Owner only."""
+    await _require_role(req, "owner")
     batch = {}
     updated = {}
     for field, value in body.model_dump(exclude_none=True).items():

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -48,8 +48,8 @@ async def get_my_role(req: Request):
 
 @rbac_router.get("/users")
 async def list_users(req: Request):
-    """List all explicit role assignments. Owner only."""
-    await _require_role(req, "owner")
+    """List all explicit role assignments. Manage or above."""
+    await _require_role(req, "manage")
     import app.services.database as _db
     return await _db.db_service.list_user_roles()
 
@@ -60,8 +60,8 @@ class RoleAssignment(BaseModel):
 
 @rbac_router.post("/users/{email}/role", status_code=200)
 async def assign_role(email: str, body: RoleAssignment, req: Request):
-    """Assign a role to a user. Owner only."""
-    identity, _, _ = await _require_role(req, "owner")
+    """Assign a role to a user. Manage or above."""
+    identity, _, _ = await _require_role(req, "manage")
     if body.role not in ROLES:
         raise HTTPException(
             status_code=400,
@@ -75,8 +75,8 @@ async def assign_role(email: str, body: RoleAssignment, req: Request):
 
 @rbac_router.delete("/users/{email}")
 async def remove_user_role(email: str, req: Request):
-    """Remove explicit role assignment (reverts to default 'use'). Owner only."""
-    identity, _, _ = await _require_role(req, "owner")
+    """Remove explicit role assignment (reverts to default 'use'). Manage or above."""
+    identity, _, _ = await _require_role(req, "manage")
     import app.services.database as _db
     await _db.db_service.delete_user_role(email)
     logger.info("Role removed: %s by %s", email, identity)

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -1,0 +1,83 @@
+"""RBAC management endpoints for user/role administration."""
+
+import logging
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.api.auth_helpers import extract_bearer_token
+from app.api.config_store import get_effective_setting
+from app.config import get_settings
+from app.services.rbac import resolve_role, role_gte, ROLES
+
+logger = logging.getLogger(__name__)
+rbac_router = APIRouter()
+_settings = get_settings()
+
+
+def _get_host() -> str:
+    host = get_effective_setting("databricks_host") or _settings.databricks_host or ""
+    if host and not host.startswith("http"):
+        host = f"https://{host}"
+    return host
+
+
+async def _resolve_caller(req: Request):
+    """Extract and resolve the calling user's identity and effective role."""
+    token = extract_bearer_token(req)
+    identity = req.headers.get("X-Forwarded-Email", "")
+    role = await resolve_role(identity, token, _get_host())
+    return identity, token, role
+
+
+async def _require_role(req: Request, min_role: str):
+    identity, token, role = await _resolve_caller(req)
+    if not role_gte(role, min_role):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{min_role}' required. You have '{role}'."
+        )
+    return identity, token, role
+
+
+@rbac_router.get("/users/me")
+async def get_my_role(req: Request):
+    """Return the current user's identity and effective role."""
+    identity, _, role = await _resolve_caller(req)
+    return {"identity": identity, "role": role}
+
+
+@rbac_router.get("/users")
+async def list_users(req: Request):
+    """List all explicit role assignments. Owner only."""
+    await _require_role(req, "owner")
+    import app.services.database as _db
+    return await _db.db_service.list_user_roles()
+
+
+class RoleAssignment(BaseModel):
+    role: str
+
+
+@rbac_router.post("/users/{email}/role", status_code=200)
+async def assign_role(email: str, body: RoleAssignment, req: Request):
+    """Assign a role to a user. Owner only."""
+    identity, _, _ = await _require_role(req, "owner")
+    if body.role not in ROLES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid role '{body.role}'. Valid roles: {ROLES}"
+        )
+    import app.services.database as _db
+    await _db.db_service.set_user_role(email, body.role, granted_by=identity)
+    logger.info("Role assigned: %s → %s by %s", email, body.role, identity)
+    return {"identity": email, "role": body.role}
+
+
+@rbac_router.delete("/users/{email}")
+async def remove_user_role(email: str, req: Request):
+    """Remove explicit role assignment (reverts to default 'use'). Owner only."""
+    identity, _, _ = await _require_role(req, "owner")
+    import app.services.database as _db
+    await _db.db_service.delete_user_role(email)
+    logger.info("Role removed: %s by %s", email, identity)
+    return {"success": True}

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -4,10 +4,11 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from app.auth import ensure_https
 from app.api.auth_helpers import extract_bearer_token
 from app.api.config_store import get_effective_setting
 from app.config import get_settings
-from app.services.rbac import resolve_role, role_gte, ROLES
+from app.services.rbac import resolve_role, role_gte, ROLES, invalidate_role_cache
 
 logger = logging.getLogger(__name__)
 rbac_router = APIRouter()
@@ -16,9 +17,7 @@ _settings = get_settings()
 
 def _get_host() -> str:
     host = get_effective_setting("databricks_host") or _settings.databricks_host or ""
-    if host and not host.startswith("http"):
-        host = f"https://{host}"
-    return host
+    return ensure_https(host) if host else host
 
 
 async def _resolve_caller(req: Request):
@@ -69,6 +68,7 @@ async def assign_role(email: str, body: RoleAssignment, req: Request):
         )
     import app.services.database as _db
     await _db.db_service.set_user_role(email, body.role, granted_by=identity)
+    invalidate_role_cache(email)
     logger.info("Role assigned: %s → %s by %s", email, body.role, identity)
     return {"identity": email, "role": body.role}
 
@@ -79,5 +79,6 @@ async def remove_user_role(email: str, req: Request):
     identity, _, _ = await _require_role(req, "manage")
     import app.services.database as _db
     await _db.db_service.delete_user_role(email)
+    invalidate_role_cache(email)
     logger.info("Role removed: %s by %s", email, identity)
     return {"success": True}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.api.routes import router
 from app.api.genie_clone_routes import genie_clone_router
 from app.api.gateway_routes import gateway_router
 from app.api.mcp_routes import mcp_router
+from app.api.rbac_routes import rbac_router
 from app.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ app.add_middleware(
 
 app.include_router(router, prefix="/api")
 app.include_router(gateway_router, prefix="/api")
+app.include_router(rbac_router, prefix="/api")
 app.include_router(genie_clone_router, prefix="/api/2.0/genie")
 app.include_router(mcp_router, prefix="/api/2.0/mcp")
 

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -157,3 +157,17 @@ class DatabaseService:
 
     async def get_gateway_stats(self, gateway_id: str) -> dict:
         return await self.backend.get_gateway_stats(gateway_id)
+
+    # --- User roles ---
+
+    async def get_user_role(self, identity: str):
+        return await self.backend.get_user_role(identity)
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        return await self.backend.set_user_role(identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        return await self.backend.list_user_roles()
+
+    async def delete_user_role(self, identity: str):
+        return await self.backend.delete_user_role(identity)

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -1,0 +1,69 @@
+"""
+Role-based access control for Genie Cache Gateway.
+
+Roles (lowest → highest privilege):
+  use     — query only: submit questions, view results
+  manage  — configure gateways, view/clear cache; cannot create/delete gateways or manage users
+  owner   — full control: create/delete gateways, manage users, configure settings
+
+Workspace admins are always treated as owner regardless of the user_roles table.
+Unassigned users default to 'use'.
+"""
+
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ROLES = ['use', 'manage', 'owner']
+ROLE_HIERARCHY = {'use': 1, 'manage': 2, 'owner': 3}
+DEFAULT_ROLE = 'use'
+
+
+def role_gte(a: str, b: str) -> bool:
+    """Return True if role a >= role b in the privilege hierarchy."""
+    return ROLE_HIERARCHY.get(a, 0) >= ROLE_HIERARCHY.get(b, 0)
+
+
+async def is_workspace_admin(token: str, host: str) -> bool:
+    """Check if the token owner is a Databricks workspace admin via SCIM /Me.
+    Workspace admins belong to the built-in 'admins' group.
+    """
+    if not token or not host:
+        return False
+    if not host.startswith("http"):
+        host = f"https://{host}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{host}/api/2.0/preview/scim/v2/Me",
+                headers={"Authorization": f"Bearer {token}"}
+            )
+            if resp.status_code == 200:
+                groups = resp.json().get("groups", [])
+                return any(g.get("display") == "admins" for g in groups)
+    except Exception as e:
+        logger.debug("Workspace admin check failed: %s", e)
+    return False
+
+
+async def resolve_role(identity: str, token: str, host: str) -> str:
+    """
+    Resolve the effective role for a user:
+    1. Workspace admins → 'owner' (checked via Databricks SCIM API)
+    2. Explicit assignment in user_roles table
+    3. Default → 'use'
+    """
+    import app.services.database as _db
+
+    # Workspace admins always get owner, regardless of any local assignment
+    if await is_workspace_admin(token, host):
+        return 'owner'
+
+    # Check explicit assignment in the database
+    if _db.db_service and identity:
+        assigned = await _db.db_service.get_user_role(identity)
+        if assigned:
+            return assigned
+
+    return DEFAULT_ROLE

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -3,15 +3,19 @@ Role-based access control for Genie Cache Gateway.
 
 Roles (lowest → highest privilege):
   use     — query only: submit questions, view results
-  manage  — configure gateways, view/clear cache; cannot create/delete gateways or manage users
-  owner   — full control: create/delete gateways, manage users, configure settings
+  manage  — configure gateways, view/clear cache, manage users
+  owner   — full control: create/delete gateways, configure settings
 
 Workspace admins are always treated as owner regardless of the user_roles table.
 Unassigned users default to 'use'.
 """
 
 import logging
+import time
+
 import httpx
+
+from app.auth import ensure_https
 
 logger = logging.getLogger(__name__)
 
@@ -19,51 +23,84 @@ ROLES = ['use', 'manage', 'owner']
 ROLE_HIERARCHY = {'use': 1, 'manage': 2, 'owner': 3}
 DEFAULT_ROLE = 'use'
 
+# Shared HTTP client — avoids per-call TCP+TLS handshake overhead
+_http_client = httpx.AsyncClient(timeout=5.0)
+
+# Short-lived in-process caches to avoid hammering SCIM and DB on every request.
+# Keys: token (admin check) and identity (role lookup). TTLs are conservative —
+# role changes take effect within the TTL window without a restart.
+_ADMIN_CACHE_TTL = 60.0   # seconds
+_ROLE_CACHE_TTL = 120.0   # seconds
+_admin_cache: dict[str, tuple[bool, float]] = {}   # token → (is_admin, expires_at)
+_role_cache: dict[str, tuple[str, float]] = {}     # identity → (role, expires_at)
+
 
 def role_gte(a: str, b: str) -> bool:
     """Return True if role a >= role b in the privilege hierarchy."""
     return ROLE_HIERARCHY.get(a, 0) >= ROLE_HIERARCHY.get(b, 0)
 
 
+def invalidate_role_cache(identity: str) -> None:
+    """Evict a cached role so the next request re-reads from the database.
+    Call this immediately after any set_user_role / delete_user_role write.
+    """
+    _role_cache.pop(identity, None)
+
+
 async def is_workspace_admin(token: str, host: str) -> bool:
     """Check if the token owner is a Databricks workspace admin via SCIM /Me.
-    Workspace admins belong to the built-in 'admins' group.
+    Result is cached for _ADMIN_CACHE_TTL seconds to avoid per-request SCIM calls.
     """
     if not token or not host:
         return False
-    if not host.startswith("http"):
-        host = f"https://{host}"
+    host = ensure_https(host)
+
+    now = time.monotonic()
+    cached = _admin_cache.get(token)
+    if cached is not None:
+        result, expires_at = cached
+        if now < expires_at:
+            return result
+
+    result = False
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(
-                f"{host}/api/2.0/preview/scim/v2/Me",
-                headers={"Authorization": f"Bearer {token}"}
-            )
-            if resp.status_code == 200:
-                groups = resp.json().get("groups", [])
-                return any(g.get("display") == "admins" for g in groups)
+        resp = await _http_client.get(
+            f"{host}/api/2.0/preview/scim/v2/Me",
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        if resp.status_code == 200:
+            groups = resp.json().get("groups", [])
+            result = any(g.get("display") == "admins" for g in groups)
     except Exception as e:
         logger.debug("Workspace admin check failed: %s", e)
-    return False
+
+    _admin_cache[token] = (result, now + _ADMIN_CACHE_TTL)
+    return result
 
 
 async def resolve_role(identity: str, token: str, host: str) -> str:
     """
     Resolve the effective role for a user:
-    1. Workspace admins → 'owner' (checked via Databricks SCIM API)
-    2. Explicit assignment in user_roles table
+    1. Workspace admins → 'owner' (checked via Databricks SCIM API, cached 60 s)
+    2. Explicit assignment in user_roles table (cached 120 s, invalidated on write)
     3. Default → 'use'
     """
     import app.services.database as _db
 
-    # Workspace admins always get owner, regardless of any local assignment
     if await is_workspace_admin(token, host):
         return 'owner'
 
-    # Check explicit assignment in the database
+    now = time.monotonic()
+    cached = _role_cache.get(identity)
+    if cached is not None:
+        role, expires_at = cached
+        if now < expires_at:
+            return role
+
+    assigned = None
     if _db.db_service and identity:
         assigned = await _db.db_service.get_user_role(identity)
-        if assigned:
-            return assigned
 
-    return DEFAULT_ROLE
+    role = assigned or DEFAULT_ROLE
+    _role_cache[identity] = (role, now + _ROLE_CACHE_TTL)
+    return role

--- a/backend/app/services/storage_dynamic.py
+++ b/backend/app/services/storage_dynamic.py
@@ -342,3 +342,29 @@ class DynamicStorageService:
         if hasattr(backend, 'pool'):
             return await backend.get_gateway_stats(gateway_id)
         return backend.get_gateway_stats(gateway_id)
+
+    # --- User roles CRUD (delegates to default backend) ---
+
+    async def get_user_role(self, identity: str):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.get_user_role(identity)
+        return backend.get_user_role(identity)
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.set_user_role(identity, role, granted_by)
+        return backend.set_user_role(identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.list_user_roles()
+        return backend.list_user_roles()
+
+    async def delete_user_role(self, identity: str):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.delete_user_role(identity)
+        return backend.delete_user_role(identity)

--- a/backend/app/services/storage_local.py
+++ b/backend/app/services/storage_local.py
@@ -30,6 +30,7 @@ class LocalStorageService:
         self.embeddings_file = embeddings_file
         self.cache_ttl_hours = cache_ttl_hours
         self._gateways: Dict = {}
+        self._user_roles: Dict = {}  # identity -> {role, granted_by, granted_at}
         self._ensure_data_dir()
         self._load_data()
 
@@ -217,6 +218,26 @@ class LocalStorageService:
         del self._gateways[gateway_id]
         logger.info("Gateway deleted: id=%s", gateway_id)
         return True
+
+    # --- User roles CRUD ---
+
+    def get_user_role(self, identity: str):
+        entry = self._user_roles.get(identity)
+        return entry["role"] if entry else None
+
+    def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        self._user_roles[identity] = {
+            "identity": identity,
+            "role": role,
+            "granted_by": granted_by,
+            "granted_at": datetime.now().isoformat() + "Z",
+        }
+
+    def list_user_roles(self) -> list:
+        return sorted(self._user_roles.values(), key=lambda r: r.get("granted_at", ""), reverse=True)
+
+    def delete_user_role(self, identity: str):
+        self._user_roles.pop(identity, None)
 
     def get_gateway_stats(self, gateway_id: str) -> Dict:
         """Get cache and query stats for a gateway."""

--- a/backend/app/services/storage_pgvector.py
+++ b/backend/app/services/storage_pgvector.py
@@ -71,6 +71,7 @@ class PGVectorStorageService:
         # Gateway table in same schema as cache table
         schema_prefix = self.table_name.rsplit('.', 1)[0] if '.' in self.table_name else 'public'
         self.gateway_table_name = f"{schema_prefix}.gateway_configs"
+        self.user_roles_table_name = f"{schema_prefix}.user_roles"
 
     def _normalize_table_name(self, table_name: str) -> str:
         """Convert Databricks catalog.schema.table to PostgreSQL schema.table format."""
@@ -172,6 +173,7 @@ class PGVectorStorageService:
             await self._ensure_table(conn)
             await self._ensure_query_log_table(conn)
             await self._ensure_gateway_table(conn)
+            await self._ensure_user_roles_table(conn)
             await self._migrate_genie_space_id_columns(conn)
             await self._migrate_original_query_text(conn)
             await self._migrate_caching_enabled(conn)
@@ -458,6 +460,18 @@ class PGVectorStorageService:
                 logger.warning("Index creation skipped: %s", e)
 
         logger.info("Query log table '%s' initialized", self.query_log_table_name)
+
+    async def _ensure_user_roles_table(self, conn):
+        """Create the user_roles table if it does not exist."""
+        await conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.user_roles_table_name} (
+                identity TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                granted_by TEXT,
+                granted_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+        logger.info("User roles table '%s' initialized", self.user_roles_table_name)
 
     async def _ensure_gateway_table(self, conn):
         """Create the gateway_configs table if it does not exist."""
@@ -961,6 +975,61 @@ class PGVectorStorageService:
             """, gateway_id) or 0
 
             return {"cache_count": cache_count, "query_count_7d": query_count, "cache_hits_7d": cache_hits}
+
+    # --- User roles CRUD ---
+
+    async def get_user_role(self, identity: str) -> Optional[str]:
+        """Return the explicit role for a user, or None if not assigned."""
+        if not self.pool:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT role FROM {self.user_roles_table_name} WHERE identity = $1",
+                identity
+            )
+            return row["role"] if row else None
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        """Insert or update a user's role assignment."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute(f"""
+                INSERT INTO {self.user_roles_table_name} (identity, role, granted_by, granted_at)
+                VALUES ($1, $2, $3, NOW())
+                ON CONFLICT (identity) DO UPDATE
+                  SET role = EXCLUDED.role,
+                      granted_by = EXCLUDED.granted_by,
+                      granted_at = NOW()
+            """, identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        """Return all explicit role assignments."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT identity, role, granted_by, granted_at FROM {self.user_roles_table_name} ORDER BY granted_at DESC"
+            )
+            return [
+                {
+                    "identity": r["identity"],
+                    "role": r["role"],
+                    "granted_by": r["granted_by"],
+                    "granted_at": _to_utc_iso(r["granted_at"]),
+                }
+                for r in rows
+            ]
+
+    async def delete_user_role(self, identity: str):
+        """Remove an explicit role assignment."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                f"DELETE FROM {self.user_roles_table_name} WHERE identity = $1",
+                identity
+            )
 
     def _row_to_gateway_dict(self, row) -> dict:
         """Convert a database row to a gateway dict."""

--- a/frontend/src/components/gateways/GatewayDetailPage.jsx
+++ b/frontend/src/components/gateways/GatewayDetailPage.jsx
@@ -2,23 +2,25 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { Trash2, Play, Copy, Loader2 } from 'lucide-react'
 import { api } from '../../services/api'
+import { useRole } from '../../context/RoleContext'
 import GatewayOverviewTab from './GatewayOverviewTab'
 import GatewayMetricsTab from './GatewayMetricsTab'
 import GatewayCacheTab from './GatewayCacheTab'
 import GatewayLogsTab from './GatewayLogsTab'
 import GatewaySettingsTab from './GatewaySettingsTab'
 
-const TABS = [
+const ALL_TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'metrics', label: 'Metrics' },
   { id: 'cache', label: 'Cache' },
   { id: 'logs', label: 'Logs' },
-  { id: 'settings', label: 'Settings' },
+  { id: 'settings', label: 'Settings', minRole: 'manage' },
 ]
 
 export default function GatewayDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const { isOwner, isManage } = useRole()
   const [gateway, setGateway] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -62,6 +64,8 @@ export default function GatewayDetailPage() {
   const copyToClipboard = (text) => {
     navigator.clipboard.writeText(text)
   }
+
+  const TABS = ALL_TABS.filter((t) => !t.minRole || isManage)
 
   if (loading) {
     return (
@@ -125,14 +129,16 @@ export default function GatewayDetailPage() {
               <Play size={14} />
               Test in Playground
             </button>
-            <button
-              onClick={handleDelete}
-              disabled={deleting}
-              className="inline-flex items-center gap-1.5 h-8 px-3 text-[13px] font-medium text-dbx-text border border-dbx-border-input rounded hover:bg-dbx-neutral-hover transition-colors disabled:opacity-50"
-            >
-              <Trash2 size={14} />
-              {deleting ? 'Deleting...' : 'Delete gateway'}
-            </button>
+            {isOwner && (
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="inline-flex items-center gap-1.5 h-8 px-3 text-[13px] font-medium text-dbx-text border border-dbx-border-input rounded hover:bg-dbx-neutral-hover transition-colors disabled:opacity-50"
+              >
+                <Trash2 size={14} />
+                {deleting ? 'Deleting...' : 'Delete gateway'}
+              </button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/gateways/GatewayListPage.jsx
+++ b/frontend/src/components/gateways/GatewayListPage.jsx
@@ -6,9 +6,11 @@ import DataTable from '../shared/DataTable'
 import StatusBadge from '../shared/StatusBadge'
 import EmptyState from '../shared/EmptyState'
 import GatewayCreateModal from './GatewayCreateModal'
+import { useRole } from '../../context/RoleContext'
 
 export default function GatewayListPage() {
   const navigate = useNavigate()
+  const { isOwner } = useRole()
   const [gateways, setGateways] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -153,13 +155,15 @@ export default function GatewayListPage() {
             Intelligent caching gateway for Databricks Genie API
           </p>
         </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
-        >
-          <Plus size={16} />
-          Gateway
-        </button>
+        {isOwner && (
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
+          >
+            <Plus size={16} />
+            Gateway
+          </button>
+        )}
       </div>
 
       {/* Search bar */}
@@ -198,7 +202,7 @@ export default function GatewayListPage() {
           icon={Layers}
           title="No gateways yet"
           description="Create a gateway to start caching Genie queries and accelerating your analytics."
-          action={
+          action={isOwner ? (
             <button
               onClick={() => setShowCreate(true)}
               className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
@@ -206,7 +210,7 @@ export default function GatewayListPage() {
               <Plus size={16} />
               Create your first gateway
             </button>
-          }
+          ) : null}
         />
       ) : (
         <DataTable
@@ -217,12 +221,13 @@ export default function GatewayListPage() {
         />
       )}
 
-      {/* Create modal */}
-      <GatewayCreateModal
-        open={showCreate}
-        onClose={() => setShowCreate(false)}
-        onCreated={handleCreated}
-      />
+      {isOwner && (
+        <GatewayCreateModal
+          open={showCreate}
+          onClose={() => setShowCreate(false)}
+          onCreated={handleCreated}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -135,14 +135,14 @@ const SIDEBAR_BASE = [
     { id: 'ai-pipeline', label: 'AI Pipeline' },
   ]},
 ]
-const SIDEBAR_OWNER = [
+const SIDEBAR_MANAGE = [
   { category: 'Access Control', icon: Users, items: [{ id: 'users', label: 'Users' }] },
 ]
 
 /* ── Main component ── */
 export default function SettingsPage() {
   const { themeMode, setThemeMode } = useTheme()
-  const { isOwner } = useRole()
+  const { isOwner, isManage } = useRole()
   const [activeSection, setActiveSection] = useState('appearance')
 
   // Users management state (owner only)
@@ -210,9 +210,9 @@ export default function SettingsPage() {
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
 
-  // Load users when owner navigates to users section
+  // Load users when manage/owner navigates to users section
   useEffect(() => {
-    if (isOwner && activeSection === 'users' && users.length === 0) {
+    if (isManage && activeSection === 'users' && users.length === 0) {
       setUsersLoading(true)
       api.listUsers()
         .then(setUsers)
@@ -241,7 +241,7 @@ export default function SettingsPage() {
     } catch { /* ignore */ }
   }
 
-  const SIDEBAR = isOwner ? [...SIDEBAR_BASE, ...SIDEBAR_OWNER] : SIDEBAR_BASE
+  const SIDEBAR = isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current
@@ -505,8 +505,8 @@ export default function SettingsPage() {
             </FieldRow>
           </div>
 
-          {/* ── Users (owner only) ── */}
-          {isOwner && (
+          {/* ── Users (manage+) ── */}
+          {isManage && (
             <div ref={el => sectionRefs.current['users'] = el} className="mb-10">
               <h2 className="text-[22px] font-semibold text-dbx-text leading-[28px] pb-3 border-b border-dbx-border">Users</h2>
 
@@ -529,7 +529,7 @@ export default function SettingsPage() {
                   <tbody>
                     {[
                       { role: 'use',    q: true,  c: false, cd: false, mu: false },
-                      { role: 'manage', q: true,  c: true,  cd: false, mu: false },
+                      { role: 'manage', q: true,  c: true,  cd: false, mu: true  },
                       { role: 'owner',  q: true,  c: true,  cd: true,  mu: true  },
                     ].map(({ role, q, c, cd, mu }) => (
                       <tr key={role} className="border-t border-dbx-border">

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette } from 'lucide-react'
+import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2 } from 'lucide-react'
 import { api } from '../../services/api'
 import { useTheme } from '../../context/ThemeContext'
+import { useRole } from '../../context/RoleContext'
 
 const secondsToTtl = (seconds) => {
   if (!seconds || seconds === 0) return { value: '0', unit: 'hours' }
@@ -125,7 +126,7 @@ function EndpointSelect({ value, onChange, endpoints, loading, placeholder, filt
 }
 
 /* ── Sidebar structure ── */
-const SIDEBAR = [
+const SIDEBAR_BASE = [
   { category: 'Preferences', icon: Palette, items: [{ id: 'appearance', label: 'Appearance' }] },
   { category: 'Connection', icon: Database, items: [{ id: 'general', label: 'General' }] },
   { category: 'Gateway Defaults', icon: SlidersHorizontal, items: [
@@ -134,11 +135,22 @@ const SIDEBAR = [
     { id: 'ai-pipeline', label: 'AI Pipeline' },
   ]},
 ]
+const SIDEBAR_OWNER = [
+  { category: 'Access Control', icon: Users, items: [{ id: 'users', label: 'Users' }] },
+]
 
 /* ── Main component ── */
 export default function SettingsPage() {
   const { themeMode, setThemeMode } = useTheme()
-  const [activeSection, setActiveSection] = useState('general')
+  const { isOwner } = useRole()
+  const [activeSection, setActiveSection] = useState('appearance')
+
+  // Users management state (owner only)
+  const [users, setUsers] = useState([])
+  const [usersLoading, setUsersLoading] = useState(false)
+  const [newUserEmail, setNewUserEmail] = useState('')
+  const [newUserRole, setNewUserRole] = useState('use')
+  const [userSaving, setUserSaving] = useState(false)
   const [config, setConfig] = useState({
     storage_backend: 'lakebase', lakebase_service_token: '', lakebase_instance_name: '',
     lakebase_catalog: 'default', lakebase_schema: 'public',
@@ -197,6 +209,39 @@ export default function SettingsPage() {
       .finally(() => setEndpointsLoading(false))
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
+
+  // Load users when owner navigates to users section
+  useEffect(() => {
+    if (isOwner && activeSection === 'users' && users.length === 0) {
+      setUsersLoading(true)
+      api.listUsers()
+        .then(setUsers)
+        .catch(() => setUsers([]))
+        .finally(() => setUsersLoading(false))
+    }
+  }, [isOwner, activeSection])
+
+  const handleAddUser = async () => {
+    if (!newUserEmail.trim()) return
+    setUserSaving(true)
+    try {
+      await api.setUserRole(newUserEmail.trim(), newUserRole)
+      const updated = await api.listUsers()
+      setUsers(updated)
+      setNewUserEmail('')
+      setNewUserRole('use')
+    } catch { /* ignore */ }
+    finally { setUserSaving(false) }
+  }
+
+  const handleRemoveUser = async (email) => {
+    try {
+      await api.deleteUserRole(email)
+      setUsers(prev => prev.filter(u => u.identity !== email))
+    } catch { /* ignore */ }
+  }
+
+  const SIDEBAR = isOwner ? [...SIDEBAR_BASE, ...SIDEBAR_OWNER] : SIDEBAR_BASE
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current
@@ -459,6 +504,122 @@ export default function SettingsPage() {
                 className={inputClass} style={{ width: '80px' }} />
             </FieldRow>
           </div>
+
+          {/* ── Users (owner only) ── */}
+          {isOwner && (
+            <div ref={el => sectionRefs.current['users'] = el} className="mb-10">
+              <h2 className="text-[22px] font-semibold text-dbx-text leading-[28px] pb-3 border-b border-dbx-border">Users</h2>
+
+              <div className="py-4 text-[12px] text-dbx-text-secondary">
+                Workspace admins always have <span className="font-semibold text-dbx-text">Owner</span> access regardless of this list.
+              </div>
+
+              {/* Role matrix */}
+              <div className="mb-6 rounded border border-dbx-border overflow-hidden text-[12px]">
+                <table className="w-full">
+                  <thead>
+                    <tr className="bg-dbx-sidebar text-dbx-text-secondary">
+                      <th className="text-left px-3 py-2 font-medium">Role</th>
+                      <th className="text-left px-3 py-2 font-medium">Query</th>
+                      <th className="text-left px-3 py-2 font-medium">Configure</th>
+                      <th className="text-left px-3 py-2 font-medium">Create/Delete</th>
+                      <th className="text-left px-3 py-2 font-medium">Manage Users</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      { role: 'use',    q: true,  c: false, cd: false, mu: false },
+                      { role: 'manage', q: true,  c: true,  cd: false, mu: false },
+                      { role: 'owner',  q: true,  c: true,  cd: true,  mu: true  },
+                    ].map(({ role, q, c, cd, mu }) => (
+                      <tr key={role} className="border-t border-dbx-border">
+                        <td className="px-3 py-2 font-medium capitalize text-dbx-text">{role}</td>
+                        {[q, c, cd, mu].map((v, i) => (
+                          <td key={i} className="px-3 py-2">
+                            <span className={v ? 'text-dbx-blue' : 'text-dbx-border-input'}>{v ? '●' : '○'}</span>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* User list */}
+              {usersLoading ? (
+                <div className="flex items-center gap-2 py-4 text-[13px] text-dbx-text-secondary">
+                  <Loader2 size={14} className="animate-spin" /> Loading users...
+                </div>
+              ) : (
+                <div className="rounded border border-dbx-border overflow-hidden mb-4 text-[13px]">
+                  {users.length === 0 ? (
+                    <div className="px-4 py-6 text-center text-dbx-text-secondary">
+                      No explicit role assignments. Add users below.
+                    </div>
+                  ) : (
+                    <table className="w-full">
+                      <thead>
+                        <tr className="bg-dbx-sidebar text-dbx-text-secondary text-[12px]">
+                          <th className="text-left px-3 py-2 font-medium">User</th>
+                          <th className="text-left px-3 py-2 font-medium">Role</th>
+                          <th className="text-left px-3 py-2 font-medium">Granted by</th>
+                          <th className="px-3 py-2" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {users.map((u) => (
+                          <tr key={u.identity} className="border-t border-dbx-border">
+                            <td className="px-3 py-2 text-dbx-text">{u.identity}</td>
+                            <td className="px-3 py-2 capitalize text-dbx-text">{u.role}</td>
+                            <td className="px-3 py-2 text-dbx-text-secondary">{u.granted_by || '—'}</td>
+                            <td className="px-3 py-2 text-right">
+                              <button
+                                onClick={() => handleRemoveUser(u.identity)}
+                                className="text-dbx-text-secondary hover:text-red-600 transition-colors p-1"
+                                title="Remove role"
+                              >
+                                <Trash2 size={13} />
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              )}
+
+              {/* Add user */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="email"
+                  placeholder="user@company.com"
+                  value={newUserEmail}
+                  onChange={(e) => setNewUserEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAddUser()}
+                  className={`${inputClass} flex-1`}
+                  style={{ maxWidth: '260px' }}
+                />
+                <select
+                  value={newUserRole}
+                  onChange={(e) => setNewUserRole(e.target.value)}
+                  className={`${inputClass} bg-dbx-bg`}
+                  style={{ width: '110px' }}
+                >
+                  <option value="use">Use</option>
+                  <option value="manage">Manage</option>
+                  <option value="owner">Owner</option>
+                </select>
+                <button
+                  onClick={handleAddUser}
+                  disabled={userSaving || !newUserEmail.trim()}
+                  className="h-8 px-3 text-[13px] text-white bg-dbx-blue rounded hover:bg-dbx-blue-dark transition-colors disabled:opacity-50"
+                >
+                  {userSaving ? <Loader2 size={13} className="animate-spin" /> : 'Add'}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* ── AI Pipeline ── */}
           <div ref={el => sectionRefs.current['ai-pipeline'] = el} className="mb-10">

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2 } from 'lucide-react'
 import { api } from '../../services/api'
 import { useTheme } from '../../context/ThemeContext'
@@ -145,12 +145,13 @@ export default function SettingsPage() {
   const { isOwner, isManage } = useRole()
   const [activeSection, setActiveSection] = useState('appearance')
 
-  // Users management state (owner only)
+  // Users management state (manage role and above)
   const [users, setUsers] = useState([])
   const [usersLoading, setUsersLoading] = useState(false)
   const [newUserEmail, setNewUserEmail] = useState('')
   const [newUserRole, setNewUserRole] = useState('use')
   const [userSaving, setUserSaving] = useState(false)
+  const usersLoadedRef = useRef(false)
   const [config, setConfig] = useState({
     storage_backend: 'lakebase', lakebase_service_token: '', lakebase_instance_name: '',
     lakebase_catalog: 'default', lakebase_schema: 'public',
@@ -210,24 +211,28 @@ export default function SettingsPage() {
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
 
-  // Load users when manage/owner navigates to users section
+  // Load users once when manage/owner navigates to the users section
   useEffect(() => {
-    if (isManage && activeSection === 'users' && users.length === 0) {
+    if (isManage && activeSection === 'users' && !usersLoadedRef.current) {
+      usersLoadedRef.current = true
       setUsersLoading(true)
       api.listUsers()
         .then(setUsers)
         .catch(() => setUsers([]))
         .finally(() => setUsersLoading(false))
     }
-  }, [isOwner, activeSection])
+  }, [isManage, activeSection])
 
   const handleAddUser = async () => {
     if (!newUserEmail.trim()) return
     setUserSaving(true)
     try {
-      await api.setUserRole(newUserEmail.trim(), newUserRole)
-      const updated = await api.listUsers()
-      setUsers(updated)
+      const saved = await api.setUserRole(newUserEmail.trim(), newUserRole)
+      // Optimistic update — upsert locally using the response, no second round-trip
+      setUsers(prev => {
+        const without = prev.filter(u => u.identity !== saved.identity)
+        return [...without, saved]
+      })
       setNewUserEmail('')
       setNewUserRole('use')
     } catch { /* ignore */ }
@@ -241,7 +246,10 @@ export default function SettingsPage() {
     } catch { /* ignore */ }
   }
 
-  const SIDEBAR = isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE
+  const SIDEBAR = useMemo(
+    () => (isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE),
+    [isManage]
+  )
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current

--- a/frontend/src/context/RoleContext.jsx
+++ b/frontend/src/context/RoleContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { api } from '../services/api'
+
+// role: 'owner' | 'manage' | 'use'
+// isOwner:  role === 'owner'
+// isManage: role === 'manage' || role === 'owner'
+
+const RoleContext = createContext({ role: 'use', isOwner: false, isManage: false, loading: true })
+
+export function RoleProvider({ children }) {
+  const [role, setRole] = useState('use')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getMyRole()
+      .then((data) => setRole(data.role || 'use'))
+      .catch(() => setRole('use'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <RoleContext.Provider value={{
+      role,
+      loading,
+      isOwner: role === 'owner',
+      isManage: role === 'manage' || role === 'owner',
+    }}>
+      {children}
+    </RoleContext.Provider>
+  )
+}
+
+export function useRole() {
+  return useContext(RoleContext)
+}

--- a/frontend/src/context/RoleContext.jsx
+++ b/frontend/src/context/RoleContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { api } from '../services/api'
 
 // role: 'owner' | 'manage' | 'use'
@@ -18,13 +18,15 @@ export function RoleProvider({ children }) {
       .finally(() => setLoading(false))
   }, [])
 
+  const value = useMemo(() => ({
+    role,
+    loading,
+    isOwner: role === 'owner',
+    isManage: role === 'manage' || role === 'owner',
+  }), [role, loading])
+
   return (
-    <RoleContext.Provider value={{
-      role,
-      loading,
-      isOwner: role === 'owner',
-      isManage: role === 'manage' || role === 'owner',
-    }}>
+    <RoleContext.Provider value={value}>
       {children}
     </RoleContext.Provider>
   )

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import { ThemeProvider } from './context/ThemeContext.jsx'
+import { RoleProvider } from './context/RoleContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider>
-        <App />
+        <RoleProvider>
+          <App />
+        </RoleProvider>
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -259,6 +259,26 @@ export const api = {
     return response.data;
   },
 
+  getMyRole: async () => {
+    const response = await axios.get(`${API_BASE_URL}/users/me`);
+    return response.data; // { identity, role }
+  },
+
+  listUsers: async () => {
+    const response = await axios.get(`${API_BASE_URL}/users`);
+    return response.data; // [{ identity, role, granted_by, granted_at }]
+  },
+
+  setUserRole: async (email, role) => {
+    const response = await axios.post(`${API_BASE_URL}/users/${encodeURIComponent(email)}/role`, { role });
+    return response.data;
+  },
+
+  deleteUserRole: async (email) => {
+    const response = await axios.delete(`${API_BASE_URL}/users/${encodeURIComponent(email)}`);
+    return response.data;
+  },
+
   getWorkspaceAppearance: async () => {
     try {
       const response = await axios.get(`${API_BASE_URL}/workspace-appearance`);


### PR DESCRIPTION
> Migrated from the original repo. See issue #19 for full context.

Closes #6

## Summary

- **Three roles**: `use` (query only), `manage` (configure gateways + clear cache + manage users), `owner` (full control)
- **Workspace admin = Owner**: Databricks workspace admins are automatically treated as owners via SCIM `/Me` check
- **Persistent storage**: `user_roles` table in Lakebase
- **Enforced on API**: gateway create/delete → owner; update/clear-cache → manage; app settings → owner
- **Frontend enforcement**: Create button, Delete button, Settings tab hidden based on role

## Permission matrix

| Role     | Query | Configure gateways | Create/Delete gateways | Manage users |
|----------|-------|--------------------|------------------------|--------------|
| `use`    | ✓     |                    |                        |              |
| `manage` | ✓     | ✓                  |                        | ✓            |
| `owner`  | ✓     | ✓                  | ✓                      | ✓            |

## Test plan

- [ ] Workspace admin sees all buttons (New Gateway, Delete, Settings tab, Users section)
- [ ] User with `use` role: only sees query + read-only views
- [ ] User with `manage` role: can configure gateways, clear cache, manage users
- [ ] Owner can add/remove role assignments from Settings → Users
- [ ] `/api/users/me` returns correct role for each user type
- [ ] Requests without user token return 401