### PR TITLE
feat: RBAC + graceful degradation when token passthrough is disabled

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -31,8 +31,8 @@ env:
     value: default
   - name: LAKEBASE_SCHEMA
     value: public
-  # RBAC bootstrap: auto-assign 'owner' on first startup when no users in DB.
-  # Required when user token passthrough is disabled.
+  # RBAC bootstrap: override for first admin email (optional).
+  # Auto-detected from app creator when empty.
   - name: BOOTSTRAP_ADMIN_EMAIL
     value: ""
 

--- a/app.yaml
+++ b/app.yaml
@@ -31,6 +31,10 @@ env:
     value: default
   - name: LAKEBASE_SCHEMA
     value: public
+  # RBAC bootstrap: auto-assign 'owner' on first startup when no users in DB.
+  # Required when user token passthrough is disabled.
+  - name: BOOTSTRAP_ADMIN_EMAIL
+    value: ""
 
 # Static files served by FastAPI (not needed here)
 

--- a/backend/app/api/auth_helpers.py
+++ b/backend/app/api/auth_helpers.py
@@ -42,6 +42,46 @@ def extract_bearer_token_optional(request: Request) -> str:
     return ""
 
 
+def resolve_user_token(request: Request) -> str:
+    """Resolve a token for Genie/SQL API calls.
+
+    Priority:
+      1. X-Forwarded-Access-Token (user token passthrough enabled)
+      2. Authorization: Bearer header (external API clients)
+      3. App's service principal token (fallback when passthrough disabled)
+
+    When falling back to SP, per-user access controls and lineage are NOT
+    enforced.  The SP must have access to the target Genie Spaces and
+    SQL Warehouses.
+    """
+    token = extract_bearer_token_optional(request)
+    if token:
+        return token
+
+    # Fallback: use the app's SP token
+    from app.auth import get_service_principal_token
+    sp_token = get_service_principal_token()
+    if sp_token:
+        logger.warning(
+            "No user token available — falling back to service principal. "
+            "Per-user access controls and data lineage are NOT enforced."
+        )
+        return sp_token
+
+    raise HTTPException(
+        status_code=401,
+        detail="No user token (passthrough disabled) and no service principal token available.",
+    )
+
+
+def resolve_user_token_optional(request: Request) -> str:
+    """Same as resolve_user_token but returns empty string instead of raising."""
+    try:
+        return resolve_user_token(request)
+    except HTTPException:
+        return ""
+
+
 def build_simple_runtime_settings(token: str):
     """Build RuntimeSettings for management endpoints that only need a user token."""
     from app.models import RuntimeConfig

--- a/backend/app/api/auth_helpers.py
+++ b/backend/app/api/auth_helpers.py
@@ -12,6 +12,22 @@ def extract_bearer_token(request: Request) -> str:
     """Extract user auth token from request headers.
     In Databricks Apps: always X-Forwarded-Access-Token.
     For direct API access: Authorization: Bearer header.
+    Raises 401 if no token is found.
+    """
+    token = extract_bearer_token_optional(request)
+    if token:
+        return token
+
+    raise HTTPException(
+        status_code=401,
+        detail="Missing authentication. Provide X-Forwarded-Access-Token or Authorization: Bearer <token>.",
+    )
+
+
+def extract_bearer_token_optional(request: Request) -> str:
+    """Extract user auth token if available, return empty string otherwise.
+    Use this when the caller can degrade gracefully without a token
+    (e.g. when user token passthrough is disabled in Databricks Apps).
     """
     forwarded = request.headers.get("X-Forwarded-Access-Token", "").strip()
     if forwarded:
@@ -23,10 +39,7 @@ def extract_bearer_token(request: Request) -> str:
         if token:
             return token
 
-    raise HTTPException(
-        status_code=401,
-        detail="Missing authentication. Provide X-Forwarded-Access-Token or Authorization: Bearer <token>.",
-    )
+    return ""
 
 
 def build_simple_runtime_settings(token: str):

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -24,19 +24,6 @@ gateway_router = APIRouter()
 settings = get_settings()
 
 
-def _get_token(req: Request) -> str:
-    """Extract bearer token from request headers."""
-    token = req.headers.get("X-Forwarded-Access-Token")
-    if not token:
-        auth = req.headers.get("Authorization", "")
-        if auth.startswith("Bearer "):
-            token = auth[7:]
-    if not token:
-        token = get_effective_setting("lakebase_service_token") or settings.databricks_token
-    if not token:
-        raise HTTPException(status_code=401, detail="No authentication token available")
-    return token
-
 
 async def _require_role(req: Request, min_role: str):
     """Resolve caller's effective role and raise 403 if below min_role.
@@ -276,7 +263,7 @@ async def get_gateway_logs(gateway_id: str, limit: int = 50):
 async def list_genie_spaces(req: Request):
     """List available Genie Spaces from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/genie/spaces"
@@ -300,7 +287,7 @@ async def list_genie_spaces(req: Request):
 async def list_warehouses(req: Request):
     """List available SQL warehouses from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/sql/warehouses"
@@ -324,7 +311,7 @@ async def list_warehouses(req: Request):
 async def list_serving_endpoints(req: Request):
     """List available serving endpoints from the workspace."""
     try:
-        token = _get_token(req)
+        token = extract_bearer_token(req)
         host = _get_host()
 
         url = f"{host}/api/2.0/serving-endpoints"

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from app.auth import ensure_https
 from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
-from app.api.auth_helpers import extract_bearer_token_optional
+from app.api.auth_helpers import extract_bearer_token_optional, resolve_user_token_optional
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
@@ -271,12 +271,12 @@ async def get_gateway_logs(gateway_id: str, limit: int = 50):
 @gateway_router.get("/workspace/genie-spaces")
 async def list_genie_spaces(req: Request):
     """List available Genie Spaces from the workspace.
-    Returns empty list when user token passthrough is disabled.
+    Returns empty list when no user token is available.
     """
     try:
-        token = extract_bearer_token_optional(req)
+        token = resolve_user_token_optional(req)
         if not token:
-            logger.info("No user token available for Genie Spaces discovery (token passthrough disabled?)")
+            logger.info("No user token available for Genie Spaces discovery")
             return {"spaces": [], "_token_passthrough": False}
         host = _get_host()
 
@@ -300,12 +300,12 @@ async def list_genie_spaces(req: Request):
 @gateway_router.get("/workspace/warehouses")
 async def list_warehouses(req: Request):
     """List available SQL warehouses from the workspace.
-    Returns empty list when user token passthrough is disabled.
+    Returns empty list when no user token is available.
     """
     try:
-        token = extract_bearer_token_optional(req)
+        token = resolve_user_token_optional(req)
         if not token:
-            logger.info("No user token available for warehouse discovery (token passthrough disabled?)")
+            logger.info("No user token available for warehouse discovery")
             return {"warehouses": [], "_token_passthrough": False}
         host = _get_host()
 
@@ -329,12 +329,12 @@ async def list_warehouses(req: Request):
 @gateway_router.get("/workspace/serving-endpoints")
 async def list_serving_endpoints(req: Request):
     """List available serving endpoints from the workspace.
-    Returns empty list when user token passthrough is disabled.
+    Returns empty list when no user token is available.
     """
     try:
-        token = extract_bearer_token_optional(req)
+        token = resolve_user_token_optional(req)
         if not token:
-            logger.info("No user token available for serving endpoints discovery (token passthrough disabled?)")
+            logger.info("No user token available for serving endpoints discovery")
             return {"endpoints": [], "_token_passthrough": False}
         host = _get_host()
 
@@ -366,6 +366,47 @@ async def list_serving_endpoints(req: Request):
     except Exception as e:
         logger.exception("Error listing serving endpoints")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@gateway_router.get("/workspace/users")
+async def list_workspace_users(req: Request):
+    """List workspace users via SCIM API.
+    Uses SP token as fallback when passthrough is disabled.
+    """
+    try:
+        token = resolve_user_token_optional(req)
+        if not token:
+            logger.info("No token available for workspace user discovery")
+            return {"users": []}
+        host = _get_host()
+
+        url = f"{host}/api/2.0/preview/scim/v2/Users"
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {token}"},
+                params={"count": 500, "attributes": "userName,displayName,active"},
+            )
+            if resp.status_code != 200:
+                logger.warning("SCIM Users API returned %d: %s", resp.status_code, resp.text[:200])
+                return {"users": []}
+            resources = resp.json().get("Resources", [])
+            return {
+                "users": [
+                    {
+                        "email": u.get("userName", ""),
+                        "displayName": u.get("displayName", u.get("userName", "")),
+                        "active": u.get("active", True),
+                    }
+                    for u in resources
+                    if u.get("userName") and u.get("active", True)
+                ]
+            }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception("Error listing workspace users")
+        return {"users": []}
 
 
 @gateway_router.post("/settings/test-connection")

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from app.auth import ensure_https
 from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
-from app.api.auth_helpers import extract_bearer_token
+from app.api.auth_helpers import extract_bearer_token_optional
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
@@ -27,10 +27,19 @@ settings = get_settings()
 
 async def _require_role(req: Request, min_role: str):
     """Resolve caller's effective role and raise 403 if below min_role.
-    Uses extract_bearer_token (user OBO token only — no service-token fallback).
+
+    When user token passthrough is disabled, falls back to email-only
+    identity (SCIM admin check is skipped, DB role lookup still works).
     """
-    token = extract_bearer_token(req)
     identity = req.headers.get("X-Forwarded-Email", "")
+    token = extract_bearer_token_optional(req)
+
+    if not token and not identity:
+        raise HTTPException(
+            status_code=401,
+            detail="No authentication token or user identity available.",
+        )
+
     host = _get_host()
     role = await resolve_role(identity, token, host)
     if not role_gte(role, min_role):
@@ -87,7 +96,7 @@ async def create_gateway(body: GatewayCreateRequest, req: Request):
             "id": str(uuid.uuid4()),
             "name": body.name,
             "genie_space_id": body.genie_space_id,
-            "sql_warehouse_id": body.sql_warehouse_id,
+            "sql_warehouse_id": body.sql_warehouse_id or "",
             "similarity_threshold": body.similarity_threshold if body.similarity_threshold is not None else 0.92,
             "max_queries_per_minute": body.max_queries_per_minute if body.max_queries_per_minute is not None else 5,
             "cache_ttl_hours": body.cache_ttl_hours if body.cache_ttl_hours is not None else 24,
@@ -261,9 +270,14 @@ async def get_gateway_logs(gateway_id: str, limit: int = 50):
 
 @gateway_router.get("/workspace/genie-spaces")
 async def list_genie_spaces(req: Request):
-    """List available Genie Spaces from the workspace."""
+    """List available Genie Spaces from the workspace.
+    Returns empty list when user token passthrough is disabled.
+    """
     try:
-        token = extract_bearer_token(req)
+        token = extract_bearer_token_optional(req)
+        if not token:
+            logger.info("No user token available for Genie Spaces discovery (token passthrough disabled?)")
+            return {"spaces": [], "_token_passthrough": False}
         host = _get_host()
 
         url = f"{host}/api/2.0/genie/spaces"
@@ -285,9 +299,14 @@ async def list_genie_spaces(req: Request):
 
 @gateway_router.get("/workspace/warehouses")
 async def list_warehouses(req: Request):
-    """List available SQL warehouses from the workspace."""
+    """List available SQL warehouses from the workspace.
+    Returns empty list when user token passthrough is disabled.
+    """
     try:
-        token = extract_bearer_token(req)
+        token = extract_bearer_token_optional(req)
+        if not token:
+            logger.info("No user token available for warehouse discovery (token passthrough disabled?)")
+            return {"warehouses": [], "_token_passthrough": False}
         host = _get_host()
 
         url = f"{host}/api/2.0/sql/warehouses"
@@ -309,9 +328,14 @@ async def list_warehouses(req: Request):
 
 @gateway_router.get("/workspace/serving-endpoints")
 async def list_serving_endpoints(req: Request):
-    """List available serving endpoints from the workspace."""
+    """List available serving endpoints from the workspace.
+    Returns empty list when user token passthrough is disabled.
+    """
     try:
-        token = extract_bearer_token(req)
+        token = extract_bearer_token_optional(req)
+        if not token:
+            logger.info("No user token available for serving endpoints discovery (token passthrough disabled?)")
+            return {"endpoints": [], "_token_passthrough": False}
         host = _get_host()
 
         url = f"{host}/api/2.0/serving-endpoints"

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -11,7 +11,9 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 
+from app.auth import ensure_https
 from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
+from app.api.auth_helpers import extract_bearer_token
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
@@ -37,8 +39,10 @@ def _get_token(req: Request) -> str:
 
 
 async def _require_role(req: Request, min_role: str):
-    """Resolve caller's effective role and raise 403 if below min_role."""
-    token = _get_token(req)
+    """Resolve caller's effective role and raise 403 if below min_role.
+    Uses extract_bearer_token (user OBO token only — no service-token fallback).
+    """
+    token = extract_bearer_token(req)
     identity = req.headers.get("X-Forwarded-Email", "")
     host = _get_host()
     role = await resolve_role(identity, token, host)
@@ -54,9 +58,7 @@ def _get_host() -> str:
     host = get_effective_setting("databricks_host") or settings.databricks_host
     if not host:
         raise HTTPException(status_code=500, detail="DATABRICKS_HOST not configured")
-    if not host.startswith("http"):
-        host = f"https://{host}"
-    return host
+    return ensure_https(host)
 
 
 # --- Gateway CRUD ---

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -15,6 +15,7 @@ from app.models import GatewayConfig, GatewayCreateRequest, GatewayUpdateRequest
 from app.api.config_store import get_effective_setting, get_overrides, update_overrides
 from app.config import get_settings
 import app.services.database as _db
+from app.services.rbac import resolve_role, role_gte
 
 logger = logging.getLogger(__name__)
 gateway_router = APIRouter()
@@ -33,6 +34,19 @@ def _get_token(req: Request) -> str:
     if not token:
         raise HTTPException(status_code=401, detail="No authentication token available")
     return token
+
+
+async def _require_role(req: Request, min_role: str):
+    """Resolve caller's effective role and raise 403 if below min_role."""
+    token = _get_token(req)
+    identity = req.headers.get("X-Forwarded-Email", "")
+    host = _get_host()
+    role = await resolve_role(identity, token, host)
+    if not role_gte(role, min_role):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{min_role}' required. You have '{role}'."
+        )
 
 
 def _get_host() -> str:
@@ -69,7 +83,8 @@ async def list_gateways():
 
 @gateway_router.post("/gateways", status_code=201)
 async def create_gateway(body: GatewayCreateRequest, req: Request):
-    """Create a new gateway configuration."""
+    """Create a new gateway configuration. Owner only."""
+    await _require_role(req, "owner")
     try:
         now = datetime.now(timezone.utc)
         user_email = req.headers.get("X-Forwarded-Email")
@@ -132,8 +147,9 @@ async def get_gateway(gateway_id: str):
 
 
 @gateway_router.put("/gateways/{gateway_id}")
-async def update_gateway(gateway_id: str, body: GatewayUpdateRequest):
-    """Update gateway fields."""
+async def update_gateway(gateway_id: str, body: GatewayUpdateRequest, req: Request):
+    """Update gateway fields. Manage or above."""
+    await _require_role(req, "manage")
     try:
         updates = body.model_dump(exclude_none=True)
         if not updates:
@@ -153,8 +169,9 @@ async def update_gateway(gateway_id: str, body: GatewayUpdateRequest):
 
 
 @gateway_router.delete("/gateways/{gateway_id}")
-async def delete_gateway(gateway_id: str):
-    """Delete a gateway."""
+async def delete_gateway(gateway_id: str, req: Request):
+    """Delete a gateway. Owner only."""
+    await _require_role(req, "owner")
     try:
         deleted = await _db.db_service.delete_gateway(gateway_id)
         if not deleted:
@@ -218,8 +235,9 @@ async def get_gateway_cache(gateway_id: str):
 
 
 @gateway_router.delete("/gateways/{gateway_id}/cache")
-async def clear_gateway_cache(gateway_id: str):
-    """Clear all cached entries for a specific gateway."""
+async def clear_gateway_cache(gateway_id: str, req: Request):
+    """Clear all cached entries for a specific gateway. Manage or above."""
+    await _require_role(req, "manage")
     try:
         gw = await _db.db_service.get_gateway(gateway_id)
         if not gw:
@@ -439,8 +457,9 @@ class SettingsUpdateRequest(GatewayUpdateRequest):
 
 
 @gateway_router.put("/settings")
-async def update_settings_endpoint(body: SettingsUpdateRequest):
-    """Update server configuration."""
+async def update_settings_endpoint(body: SettingsUpdateRequest, req: Request):
+    """Update server configuration. Owner only."""
+    await _require_role(req, "owner")
     batch = {}
     updated = {}
     for field, value in body.model_dump(exclude_none=True).items():

--- a/backend/app/api/genie_clone_routes.py
+++ b/backend/app/api/genie_clone_routes.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from app.auth import ensure_https
 from app.config import get_settings
 from app.api.config_store import get_effective_setting
-from app.api.auth_helpers import extract_bearer_token
+from app.api.auth_helpers import extract_bearer_token, extract_bearer_token_optional, resolve_user_token  # noqa: F401
 from app.services.embedding_service import embedding_service
 from app.services.genie_service import genie_service, GenieRateLimitError, GenieConfigError
 from app.utils import exponential_backoff
@@ -66,8 +66,8 @@ def _release_message_lock(msg_id: str) -> None:
 
 
 def _extract_token(request: Request) -> str:
-    """Extract auth token from request headers."""
-    return extract_bearer_token(request)
+    """Extract auth token: passthrough → Bearer → SP fallback."""
+    return resolve_user_token(request)
 
 
 async def _resolve_gateway_space_id(space_id: str) -> tuple[str, dict | None]:

--- a/backend/app/api/genie_clone_routes.py
+++ b/backend/app/api/genie_clone_routes.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from app.auth import ensure_https
 from app.config import get_settings
 from app.api.config_store import get_effective_setting
-from app.api.auth_helpers import extract_bearer_token, extract_bearer_token_optional, resolve_user_token  # noqa: F401
+from app.api.auth_helpers import resolve_user_token
 from app.services.embedding_service import embedding_service
 from app.services.genie_service import genie_service, GenieRateLimitError, GenieConfigError
 from app.utils import exponential_backoff

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
 from app.auth import ensure_https
-from app.api.auth_helpers import extract_bearer_token
+from app.api.auth_helpers import extract_bearer_token_optional
 from app.api.config_store import get_effective_setting
 from app.config import get_settings
 from app.services.rbac import resolve_role, role_gte, ROLES, invalidate_role_cache
@@ -21,9 +21,23 @@ def _get_host() -> str:
 
 
 async def _resolve_caller(req: Request):
-    """Extract and resolve the calling user's identity and effective role."""
-    token = extract_bearer_token(req)
+    """Extract and resolve the calling user's identity and effective role.
+
+    When user token passthrough is disabled in Databricks Apps, the user's
+    OAuth token is unavailable.  We still identify the user via the
+    X-Forwarded-Email header (always present for SSO-authenticated users)
+    and resolve their role from the database.  The SCIM workspace-admin
+    check is skipped (requires the user's own token).
+    """
     identity = req.headers.get("X-Forwarded-Email", "")
+    token = extract_bearer_token_optional(req)
+
+    if not token and not identity:
+        raise HTTPException(
+            status_code=401,
+            detail="No authentication token or user identity available.",
+        )
+
     role = await resolve_role(identity, token, _get_host())
     return identity, token, role
 

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -48,8 +48,8 @@ async def get_my_role(req: Request):
 
 @rbac_router.get("/users")
 async def list_users(req: Request):
-    """List all explicit role assignments. Owner only."""
-    await _require_role(req, "owner")
+    """List all explicit role assignments. Manage or above."""
+    await _require_role(req, "manage")
     import app.services.database as _db
     return await _db.db_service.list_user_roles()
 
@@ -60,8 +60,8 @@ class RoleAssignment(BaseModel):
 
 @rbac_router.post("/users/{email}/role", status_code=200)
 async def assign_role(email: str, body: RoleAssignment, req: Request):
-    """Assign a role to a user. Owner only."""
-    identity, _, _ = await _require_role(req, "owner")
+    """Assign a role to a user. Manage or above."""
+    identity, _, _ = await _require_role(req, "manage")
     if body.role not in ROLES:
         raise HTTPException(
             status_code=400,
@@ -75,8 +75,8 @@ async def assign_role(email: str, body: RoleAssignment, req: Request):
 
 @rbac_router.delete("/users/{email}")
 async def remove_user_role(email: str, req: Request):
-    """Remove explicit role assignment (reverts to default 'use'). Owner only."""
-    identity, _, _ = await _require_role(req, "owner")
+    """Remove explicit role assignment (reverts to default 'use'). Manage or above."""
+    identity, _, _ = await _require_role(req, "manage")
     import app.services.database as _db
     await _db.db_service.delete_user_role(email)
     logger.info("Role removed: %s by %s", email, identity)

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -1,0 +1,83 @@
+"""RBAC management endpoints for user/role administration."""
+
+import logging
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from app.api.auth_helpers import extract_bearer_token
+from app.api.config_store import get_effective_setting
+from app.config import get_settings
+from app.services.rbac import resolve_role, role_gte, ROLES
+
+logger = logging.getLogger(__name__)
+rbac_router = APIRouter()
+_settings = get_settings()
+
+
+def _get_host() -> str:
+    host = get_effective_setting("databricks_host") or _settings.databricks_host or ""
+    if host and not host.startswith("http"):
+        host = f"https://{host}"
+    return host
+
+
+async def _resolve_caller(req: Request):
+    """Extract and resolve the calling user's identity and effective role."""
+    token = extract_bearer_token(req)
+    identity = req.headers.get("X-Forwarded-Email", "")
+    role = await resolve_role(identity, token, _get_host())
+    return identity, token, role
+
+
+async def _require_role(req: Request, min_role: str):
+    identity, token, role = await _resolve_caller(req)
+    if not role_gte(role, min_role):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{min_role}' required. You have '{role}'."
+        )
+    return identity, token, role
+
+
+@rbac_router.get("/users/me")
+async def get_my_role(req: Request):
+    """Return the current user's identity and effective role."""
+    identity, _, role = await _resolve_caller(req)
+    return {"identity": identity, "role": role}
+
+
+@rbac_router.get("/users")
+async def list_users(req: Request):
+    """List all explicit role assignments. Owner only."""
+    await _require_role(req, "owner")
+    import app.services.database as _db
+    return await _db.db_service.list_user_roles()
+
+
+class RoleAssignment(BaseModel):
+    role: str
+
+
+@rbac_router.post("/users/{email}/role", status_code=200)
+async def assign_role(email: str, body: RoleAssignment, req: Request):
+    """Assign a role to a user. Owner only."""
+    identity, _, _ = await _require_role(req, "owner")
+    if body.role not in ROLES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid role '{body.role}'. Valid roles: {ROLES}"
+        )
+    import app.services.database as _db
+    await _db.db_service.set_user_role(email, body.role, granted_by=identity)
+    logger.info("Role assigned: %s → %s by %s", email, body.role, identity)
+    return {"identity": email, "role": body.role}
+
+
+@rbac_router.delete("/users/{email}")
+async def remove_user_role(email: str, req: Request):
+    """Remove explicit role assignment (reverts to default 'use'). Owner only."""
+    identity, _, _ = await _require_role(req, "owner")
+    import app.services.database as _db
+    await _db.db_service.delete_user_role(email)
+    logger.info("Role removed: %s by %s", email, identity)
+    return {"success": True}

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -59,6 +59,22 @@ async def get_my_role(req: Request):
     return {"identity": identity, "role": role}
 
 
+@rbac_router.get("/auth/mode")
+async def get_auth_mode(req: Request):
+    """Report whether the app is using user token passthrough or SP fallback."""
+    token = extract_bearer_token_optional(req)
+    if token:
+        return {"auth_mode": "user", "message": "User token passthrough is active."}
+    return {
+        "auth_mode": "service_principal",
+        "message": (
+            "User token passthrough is disabled. Queries use the app's service principal. "
+            "Grant the SP access to Genie Spaces and SQL Warehouses. "
+            "Per-user access controls and lineage are not enforced."
+        ),
+    }
+
+
 @rbac_router.get("/users")
 async def list_users(req: Request):
     """List all explicit role assignments. Manage or above."""
@@ -71,6 +87,19 @@ class RoleAssignment(BaseModel):
     role: str
 
 
+async def _check_last_owner(email: str, new_role: str = None):
+    """Prevent removing or downgrading the last owner."""
+    import app.services.database as _db
+    all_roles = await _db.db_service.list_user_roles()
+    owners = [u for u in all_roles if u.get("role") == "owner"]
+    is_target_owner = any(u["identity"] == email for u in owners)
+    if is_target_owner and len(owners) <= 1 and new_role != "owner":
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot remove or downgrade the last owner. Assign another owner first.",
+        )
+
+
 @rbac_router.post("/users/{email}/role", status_code=200)
 async def assign_role(email: str, body: RoleAssignment, req: Request):
     """Assign a role to a user. Manage or above."""
@@ -80,17 +109,19 @@ async def assign_role(email: str, body: RoleAssignment, req: Request):
             status_code=400,
             detail=f"Invalid role '{body.role}'. Valid roles: {ROLES}"
         )
+    await _check_last_owner(email, body.role)
     import app.services.database as _db
     await _db.db_service.set_user_role(email, body.role, granted_by=identity)
     invalidate_role_cache(email)
     logger.info("Role assigned: %s → %s by %s", email, body.role, identity)
-    return {"identity": email, "role": body.role}
+    return {"identity": email, "role": body.role, "granted_by": identity}
 
 
 @rbac_router.delete("/users/{email}")
 async def remove_user_role(email: str, req: Request):
     """Remove explicit role assignment (reverts to default 'use'). Manage or above."""
     identity, _, _ = await _require_role(req, "manage")
+    await _check_last_owner(email)
     import app.services.database as _db
     await _db.db_service.delete_user_role(email)
     invalidate_role_cache(email)

--- a/backend/app/api/rbac_routes.py
+++ b/backend/app/api/rbac_routes.py
@@ -4,10 +4,11 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from app.auth import ensure_https
 from app.api.auth_helpers import extract_bearer_token
 from app.api.config_store import get_effective_setting
 from app.config import get_settings
-from app.services.rbac import resolve_role, role_gte, ROLES
+from app.services.rbac import resolve_role, role_gte, ROLES, invalidate_role_cache
 
 logger = logging.getLogger(__name__)
 rbac_router = APIRouter()
@@ -16,9 +17,7 @@ _settings = get_settings()
 
 def _get_host() -> str:
     host = get_effective_setting("databricks_host") or _settings.databricks_host or ""
-    if host and not host.startswith("http"):
-        host = f"https://{host}"
-    return host
+    return ensure_https(host) if host else host
 
 
 async def _resolve_caller(req: Request):
@@ -69,6 +68,7 @@ async def assign_role(email: str, body: RoleAssignment, req: Request):
         )
     import app.services.database as _db
     await _db.db_service.set_user_role(email, body.role, granted_by=identity)
+    invalidate_role_cache(email)
     logger.info("Role assigned: %s → %s by %s", email, body.role, identity)
     return {"identity": email, "role": body.role}
 
@@ -79,5 +79,6 @@ async def remove_user_role(email: str, req: Request):
     identity, _, _ = await _require_role(req, "manage")
     import app.services.database as _db
     await _db.db_service.delete_user_role(email)
+    invalidate_role_cache(email)
     logger.info("Role removed: %s by %s", email, identity)
     return {"success": True}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -36,7 +36,8 @@ settings = get_settings()
 @router.post("/query", response_model=QueryResponse)
 async def submit_query(request: QueryRequest, req: Request):
     try:
-        token = req.headers.get("X-Forwarded-Access-Token") or ""
+        from app.api.auth_helpers import resolve_user_token
+        token = resolve_user_token(req)
         identity = req.headers.get("X-Forwarded-Email") or ""
 
         if not identity:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     # when no users exist in the DB.  Required when user token passthrough is
     # disabled (workspace admin auto-detection via SCIM is unavailable).
     bootstrap_admin_email: str = os.getenv("BOOTSTRAP_ADMIN_EMAIL", "")
-    
+
     # Application settings
     max_queries_per_minute: int = int(os.getenv("MAX_QUERIES_PER_MINUTE", "5"))
     similarity_threshold: float = float(os.getenv("SIMILARITY_THRESHOLD", "0.92"))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     
     # Application environment
     app_env: str = os.getenv("APP_ENV", "development")  # development, production
+
+    # RBAC bootstrap: auto-assign 'owner' role to this email on first startup
+    # when no users exist in the DB.  Required when user token passthrough is
+    # disabled (workspace admin auto-detection via SCIM is unavailable).
+    bootstrap_admin_email: str = os.getenv("BOOTSTRAP_ADMIN_EMAIL", "")
     
     # Application settings
     max_queries_per_minute: int = int(os.getenv("MAX_QUERIES_PER_MINUTE", "5"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,10 @@ async def lifespan(app: FastAPI):
     from app.services.database import initialize_storage
     storage = await initialize_storage()
 
+    # Bootstrap first admin if BOOTSTRAP_ADMIN_EMAIL is set and no users exist
+    from app.services.rbac import bootstrap_admin_if_needed
+    await bootstrap_admin_if_needed()
+
     # Start periodic JWT refresh for all Lakebase backends
     refresh_task = None
     if settings.storage_backend == "pgvector" and settings.lakebase_instance:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.api.routes import router
 from app.api.genie_clone_routes import genie_clone_router
 from app.api.gateway_routes import gateway_router
 from app.api.mcp_routes import mcp_router
+from app.api.rbac_routes import rbac_router
 from app.config import get_settings
 
 logger = logging.getLogger(__name__)
@@ -78,6 +79,7 @@ app.add_middleware(
 
 app.include_router(router, prefix="/api")
 app.include_router(gateway_router, prefix="/api")
+app.include_router(rbac_router, prefix="/api")
 app.include_router(genie_clone_router, prefix="/api/2.0/genie")
 app.include_router(mcp_router, prefix="/api/2.0/mcp")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,54 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 
+REQUIRED_USER_SCOPES = ["sql", "dashboards.genie", "serving.serving-endpoints"]
+
+
+async def _ensure_oauth_scopes():
+    """Ensure the Databricks App has the required OAuth scopes for user passthrough.
+    Automatically patches the app config on startup if scopes are missing.
+    """
+    import os
+    import httpx
+    from app.auth import get_service_principal_token, ensure_https
+
+    app_name = os.environ.get("DATABRICKS_APP_NAME", "")
+    if not app_name:
+        return  # Not running as a Databricks App
+
+    token = get_service_principal_token()
+    host = ensure_https(settings.databricks_host)
+    if not token or not host:
+        return
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{host}/api/2.0/apps/{app_name}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code != 200:
+                return
+            current = set(resp.json().get("user_api_scopes") or [])
+            needed = set(REQUIRED_USER_SCOPES)
+            if needed.issubset(current):
+                logger.debug("OAuth scopes already configured: %s", current)
+                return
+
+            merged = list(current | needed)
+            patch = await client.patch(
+                f"{host}/api/2.0/apps/{app_name}",
+                headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+                json={"user_api_scopes": merged},
+            )
+            if patch.status_code == 200:
+                logger.info("OAuth scopes updated: %s", merged)
+            else:
+                logger.warning("Failed to update OAuth scopes: %d %s", patch.status_code, patch.text[:200])
+    except Exception as e:
+        logger.debug("Could not ensure OAuth scopes: %s", e)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Initialize storage backend (creates connection pool if using Lakebase/PGVector)
@@ -34,6 +82,9 @@ async def lifespan(app: FastAPI):
     # Bootstrap first admin if BOOTSTRAP_ADMIN_EMAIL is set and no users exist
     from app.services.rbac import bootstrap_admin_if_needed
     await bootstrap_admin_if_needed()
+
+    # Ensure the app has the required OAuth scopes for user token passthrough
+    await _ensure_oauth_scopes()
 
     # Start periodic JWT refresh for all Lakebase backends
     refresh_task = None

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -157,3 +157,17 @@ class DatabaseService:
 
     async def get_gateway_stats(self, gateway_id: str) -> dict:
         return await self.backend.get_gateway_stats(gateway_id)
+
+    # --- User roles ---
+
+    async def get_user_role(self, identity: str):
+        return await self.backend.get_user_role(identity)
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        return await self.backend.set_user_role(identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        return await self.backend.list_user_roles()
+
+    async def delete_user_role(self, identity: str):
+        return await self.backend.delete_user_role(identity)

--- a/backend/app/services/genie_service.py
+++ b/backend/app/services/genie_service.py
@@ -45,7 +45,7 @@ class GenieService:
             token = runtime_settings.databricks_token
 
             if not token or (isinstance(token, str) and token.strip() == ""):
-                logger.warning("Empty X-Forwarded-Access-Token — Genie call will fail")
+                logger.warning("Empty user token — Genie call will fail")
 
             return (
                 f"{host}/api/2.0/genie",

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -83,7 +83,6 @@ async def _detect_app_creator() -> str:
     Uses the app's SP credentials to call the Apps API.
     """
     import os
-    import httpx
     from app.auth import get_service_principal_token, ensure_https
     from app.config import get_settings
 
@@ -97,16 +96,15 @@ async def _detect_app_creator() -> str:
         return ""
 
     try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                f"{host}/api/2.0/apps/{app_name}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-            if resp.status_code == 200:
-                creator = resp.json().get("creator", "")
-                if creator:
-                    logger.info("Detected app creator: %s", creator)
-                return creator
+        resp = await _http_client.get(
+            f"{host}/api/2.0/apps/{app_name}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        if resp.status_code == 200:
+            creator = resp.json().get("creator", "")
+            if creator:
+                logger.info("Detected app creator: %s", creator)
+            return creator
     except Exception as e:
         logger.debug("Could not detect app creator: %s", e)
     return ""

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -1,0 +1,69 @@
+"""
+Role-based access control for Genie Cache Gateway.
+
+Roles (lowest → highest privilege):
+  use     — query only: submit questions, view results
+  manage  — configure gateways, view/clear cache; cannot create/delete gateways or manage users
+  owner   — full control: create/delete gateways, manage users, configure settings
+
+Workspace admins are always treated as owner regardless of the user_roles table.
+Unassigned users default to 'use'.
+"""
+
+import logging
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ROLES = ['use', 'manage', 'owner']
+ROLE_HIERARCHY = {'use': 1, 'manage': 2, 'owner': 3}
+DEFAULT_ROLE = 'use'
+
+
+def role_gte(a: str, b: str) -> bool:
+    """Return True if role a >= role b in the privilege hierarchy."""
+    return ROLE_HIERARCHY.get(a, 0) >= ROLE_HIERARCHY.get(b, 0)
+
+
+async def is_workspace_admin(token: str, host: str) -> bool:
+    """Check if the token owner is a Databricks workspace admin via SCIM /Me.
+    Workspace admins belong to the built-in 'admins' group.
+    """
+    if not token or not host:
+        return False
+    if not host.startswith("http"):
+        host = f"https://{host}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{host}/api/2.0/preview/scim/v2/Me",
+                headers={"Authorization": f"Bearer {token}"}
+            )
+            if resp.status_code == 200:
+                groups = resp.json().get("groups", [])
+                return any(g.get("display") == "admins" for g in groups)
+    except Exception as e:
+        logger.debug("Workspace admin check failed: %s", e)
+    return False
+
+
+async def resolve_role(identity: str, token: str, host: str) -> str:
+    """
+    Resolve the effective role for a user:
+    1. Workspace admins → 'owner' (checked via Databricks SCIM API)
+    2. Explicit assignment in user_roles table
+    3. Default → 'use'
+    """
+    import app.services.database as _db
+
+    # Workspace admins always get owner, regardless of any local assignment
+    if await is_workspace_admin(token, host):
+        return 'owner'
+
+    # Check explicit assignment in the database
+    if _db.db_service and identity:
+        assigned = await _db.db_service.get_user_role(identity)
+        if assigned:
+            return assigned
+
+    return DEFAULT_ROLE

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -78,24 +78,64 @@ async def is_workspace_admin(token: str, host: str) -> bool:
     return result
 
 
-async def bootstrap_admin_if_needed() -> None:
-    """Auto-assign 'owner' to BOOTSTRAP_ADMIN_EMAIL if no users exist in the DB.
+async def _detect_app_creator() -> str:
+    """Get the email of the user who created this Databricks App.
+    Uses the app's SP credentials to call the Apps API.
+    """
+    import os
+    import httpx
+    from app.auth import get_service_principal_token, ensure_https
+    from app.config import get_settings
 
-    This is the recommended way to seed the first admin when user token
-    passthrough is disabled — SCIM auto-detection cannot work without the
-    user's own OAuth token.
+    app_name = os.environ.get("DATABRICKS_APP_NAME", "")
+    if not app_name:
+        return ""
+
+    token = get_service_principal_token()
+    host = ensure_https(get_settings().databricks_host)
+    if not token or not host:
+        return ""
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{host}/api/2.0/apps/{app_name}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            if resp.status_code == 200:
+                creator = resp.json().get("creator", "")
+                if creator:
+                    logger.info("Detected app creator: %s", creator)
+                return creator
+    except Exception as e:
+        logger.debug("Could not detect app creator: %s", e)
+    return ""
+
+
+async def bootstrap_admin_if_needed() -> None:
+    """Auto-assign 'owner' to the first admin if no users exist in the DB.
+
+    Resolution order for the bootstrap email:
+      1. BOOTSTRAP_ADMIN_EMAIL env var (explicit override)
+      2. App creator (auto-detected from Databricks Apps API)
     """
     import app.services.database as _db
     from app.config import get_settings
 
-    email = get_settings().bootstrap_admin_email
-    if not email or not _db.db_service:
+    if not _db.db_service:
         return
 
     try:
         existing = await _db.db_service.list_user_roles()
         if existing:
             logger.debug("Bootstrap skipped — %d user(s) already in DB", len(existing))
+            return
+
+        email = get_settings().bootstrap_admin_email
+        if not email:
+            email = await _detect_app_creator()
+        if not email:
+            logger.warning("Bootstrap skipped — no BOOTSTRAP_ADMIN_EMAIL and could not detect app creator")
             return
 
         await _db.db_service.set_user_role(email, "owner", granted_by="bootstrap")

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -3,15 +3,19 @@ Role-based access control for Genie Cache Gateway.
 
 Roles (lowest → highest privilege):
   use     — query only: submit questions, view results
-  manage  — configure gateways, view/clear cache; cannot create/delete gateways or manage users
-  owner   — full control: create/delete gateways, manage users, configure settings
+  manage  — configure gateways, view/clear cache, manage users
+  owner   — full control: create/delete gateways, configure settings
 
 Workspace admins are always treated as owner regardless of the user_roles table.
 Unassigned users default to 'use'.
 """
 
 import logging
+import time
+
 import httpx
+
+from app.auth import ensure_https
 
 logger = logging.getLogger(__name__)
 
@@ -19,51 +23,84 @@ ROLES = ['use', 'manage', 'owner']
 ROLE_HIERARCHY = {'use': 1, 'manage': 2, 'owner': 3}
 DEFAULT_ROLE = 'use'
 
+# Shared HTTP client — avoids per-call TCP+TLS handshake overhead
+_http_client = httpx.AsyncClient(timeout=5.0)
+
+# Short-lived in-process caches to avoid hammering SCIM and DB on every request.
+# Keys: token (admin check) and identity (role lookup). TTLs are conservative —
+# role changes take effect within the TTL window without a restart.
+_ADMIN_CACHE_TTL = 60.0   # seconds
+_ROLE_CACHE_TTL = 120.0   # seconds
+_admin_cache: dict[str, tuple[bool, float]] = {}   # token → (is_admin, expires_at)
+_role_cache: dict[str, tuple[str, float]] = {}     # identity → (role, expires_at)
+
 
 def role_gte(a: str, b: str) -> bool:
     """Return True if role a >= role b in the privilege hierarchy."""
     return ROLE_HIERARCHY.get(a, 0) >= ROLE_HIERARCHY.get(b, 0)
 
 
+def invalidate_role_cache(identity: str) -> None:
+    """Evict a cached role so the next request re-reads from the database.
+    Call this immediately after any set_user_role / delete_user_role write.
+    """
+    _role_cache.pop(identity, None)
+
+
 async def is_workspace_admin(token: str, host: str) -> bool:
     """Check if the token owner is a Databricks workspace admin via SCIM /Me.
-    Workspace admins belong to the built-in 'admins' group.
+    Result is cached for _ADMIN_CACHE_TTL seconds to avoid per-request SCIM calls.
     """
     if not token or not host:
         return False
-    if not host.startswith("http"):
-        host = f"https://{host}"
+    host = ensure_https(host)
+
+    now = time.monotonic()
+    cached = _admin_cache.get(token)
+    if cached is not None:
+        result, expires_at = cached
+        if now < expires_at:
+            return result
+
+    result = False
     try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(
-                f"{host}/api/2.0/preview/scim/v2/Me",
-                headers={"Authorization": f"Bearer {token}"}
-            )
-            if resp.status_code == 200:
-                groups = resp.json().get("groups", [])
-                return any(g.get("display") == "admins" for g in groups)
+        resp = await _http_client.get(
+            f"{host}/api/2.0/preview/scim/v2/Me",
+            headers={"Authorization": f"Bearer {token}"}
+        )
+        if resp.status_code == 200:
+            groups = resp.json().get("groups", [])
+            result = any(g.get("display") == "admins" for g in groups)
     except Exception as e:
         logger.debug("Workspace admin check failed: %s", e)
-    return False
+
+    _admin_cache[token] = (result, now + _ADMIN_CACHE_TTL)
+    return result
 
 
 async def resolve_role(identity: str, token: str, host: str) -> str:
     """
     Resolve the effective role for a user:
-    1. Workspace admins → 'owner' (checked via Databricks SCIM API)
-    2. Explicit assignment in user_roles table
+    1. Workspace admins → 'owner' (checked via Databricks SCIM API, cached 60 s)
+    2. Explicit assignment in user_roles table (cached 120 s, invalidated on write)
     3. Default → 'use'
     """
     import app.services.database as _db
 
-    # Workspace admins always get owner, regardless of any local assignment
     if await is_workspace_admin(token, host):
         return 'owner'
 
-    # Check explicit assignment in the database
+    now = time.monotonic()
+    cached = _role_cache.get(identity)
+    if cached is not None:
+        role, expires_at = cached
+        if now < expires_at:
+            return role
+
+    assigned = None
     if _db.db_service and identity:
         assigned = await _db.db_service.get_user_role(identity)
-        if assigned:
-            return assigned
 
-    return DEFAULT_ROLE
+    role = assigned or DEFAULT_ROLE
+    _role_cache[identity] = (role, now + _ROLE_CACHE_TTL)
+    return role

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -78,6 +78,32 @@ async def is_workspace_admin(token: str, host: str) -> bool:
     return result
 
 
+async def bootstrap_admin_if_needed() -> None:
+    """Auto-assign 'owner' to BOOTSTRAP_ADMIN_EMAIL if no users exist in the DB.
+
+    This is the recommended way to seed the first admin when user token
+    passthrough is disabled — SCIM auto-detection cannot work without the
+    user's own OAuth token.
+    """
+    import app.services.database as _db
+    from app.config import get_settings
+
+    email = get_settings().bootstrap_admin_email
+    if not email or not _db.db_service:
+        return
+
+    try:
+        existing = await _db.db_service.list_user_roles()
+        if existing:
+            logger.debug("Bootstrap skipped — %d user(s) already in DB", len(existing))
+            return
+
+        await _db.db_service.set_user_role(email, "owner", granted_by="bootstrap")
+        logger.info("Bootstrap: assigned 'owner' role to %s", email)
+    except Exception as e:
+        logger.error("Bootstrap admin failed: %s", e)
+
+
 async def resolve_role(identity: str, token: str, host: str) -> str:
     """
     Resolve the effective role for a user:

--- a/backend/app/services/storage_dynamic.py
+++ b/backend/app/services/storage_dynamic.py
@@ -342,3 +342,29 @@ class DynamicStorageService:
         if hasattr(backend, 'pool'):
             return await backend.get_gateway_stats(gateway_id)
         return backend.get_gateway_stats(gateway_id)
+
+    # --- User roles CRUD (delegates to default backend) ---
+
+    async def get_user_role(self, identity: str):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.get_user_role(identity)
+        return backend.get_user_role(identity)
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.set_user_role(identity, role, granted_by)
+        return backend.set_user_role(identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.list_user_roles()
+        return backend.list_user_roles()
+
+    async def delete_user_role(self, identity: str):
+        backend = self.default_backend
+        if hasattr(backend, 'pool'):
+            return await backend.delete_user_role(identity)
+        return backend.delete_user_role(identity)

--- a/backend/app/services/storage_local.py
+++ b/backend/app/services/storage_local.py
@@ -30,6 +30,7 @@ class LocalStorageService:
         self.embeddings_file = embeddings_file
         self.cache_ttl_hours = cache_ttl_hours
         self._gateways: Dict = {}
+        self._user_roles: Dict = {}  # identity -> {role, granted_by, granted_at}
         self._ensure_data_dir()
         self._load_data()
 
@@ -217,6 +218,26 @@ class LocalStorageService:
         del self._gateways[gateway_id]
         logger.info("Gateway deleted: id=%s", gateway_id)
         return True
+
+    # --- User roles CRUD ---
+
+    def get_user_role(self, identity: str):
+        entry = self._user_roles.get(identity)
+        return entry["role"] if entry else None
+
+    def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        self._user_roles[identity] = {
+            "identity": identity,
+            "role": role,
+            "granted_by": granted_by,
+            "granted_at": datetime.now().isoformat() + "Z",
+        }
+
+    def list_user_roles(self) -> list:
+        return sorted(self._user_roles.values(), key=lambda r: r.get("granted_at", ""), reverse=True)
+
+    def delete_user_role(self, identity: str):
+        self._user_roles.pop(identity, None)
 
     def get_gateway_stats(self, gateway_id: str) -> Dict:
         """Get cache and query stats for a gateway."""

--- a/backend/app/services/storage_pgvector.py
+++ b/backend/app/services/storage_pgvector.py
@@ -71,6 +71,7 @@ class PGVectorStorageService:
         # Gateway table in same schema as cache table
         schema_prefix = self.table_name.rsplit('.', 1)[0] if '.' in self.table_name else 'public'
         self.gateway_table_name = f"{schema_prefix}.gateway_configs"
+        self.user_roles_table_name = f"{schema_prefix}.user_roles"
 
     def _normalize_table_name(self, table_name: str) -> str:
         """Convert Databricks catalog.schema.table to PostgreSQL schema.table format."""
@@ -172,6 +173,7 @@ class PGVectorStorageService:
             await self._ensure_table(conn)
             await self._ensure_query_log_table(conn)
             await self._ensure_gateway_table(conn)
+            await self._ensure_user_roles_table(conn)
             await self._migrate_genie_space_id_columns(conn)
             await self._migrate_original_query_text(conn)
             await self._migrate_caching_enabled(conn)
@@ -458,6 +460,18 @@ class PGVectorStorageService:
                 logger.warning("Index creation skipped: %s", e)
 
         logger.info("Query log table '%s' initialized", self.query_log_table_name)
+
+    async def _ensure_user_roles_table(self, conn):
+        """Create the user_roles table if it does not exist."""
+        await conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.user_roles_table_name} (
+                identity TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                granted_by TEXT,
+                granted_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+        logger.info("User roles table '%s' initialized", self.user_roles_table_name)
 
     async def _ensure_gateway_table(self, conn):
         """Create the gateway_configs table if it does not exist."""
@@ -961,6 +975,61 @@ class PGVectorStorageService:
             """, gateway_id) or 0
 
             return {"cache_count": cache_count, "query_count_7d": query_count, "cache_hits_7d": cache_hits}
+
+    # --- User roles CRUD ---
+
+    async def get_user_role(self, identity: str) -> Optional[str]:
+        """Return the explicit role for a user, or None if not assigned."""
+        if not self.pool:
+            return None
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT role FROM {self.user_roles_table_name} WHERE identity = $1",
+                identity
+            )
+            return row["role"] if row else None
+
+    async def set_user_role(self, identity: str, role: str, granted_by: str = None):
+        """Insert or update a user's role assignment."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute(f"""
+                INSERT INTO {self.user_roles_table_name} (identity, role, granted_by, granted_at)
+                VALUES ($1, $2, $3, NOW())
+                ON CONFLICT (identity) DO UPDATE
+                  SET role = EXCLUDED.role,
+                      granted_by = EXCLUDED.granted_by,
+                      granted_at = NOW()
+            """, identity, role, granted_by)
+
+    async def list_user_roles(self) -> list:
+        """Return all explicit role assignments."""
+        if not self.pool:
+            return []
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT identity, role, granted_by, granted_at FROM {self.user_roles_table_name} ORDER BY granted_at DESC"
+            )
+            return [
+                {
+                    "identity": r["identity"],
+                    "role": r["role"],
+                    "granted_by": r["granted_by"],
+                    "granted_at": _to_utc_iso(r["granted_at"]),
+                }
+                for r in rows
+            ]
+
+    async def delete_user_role(self, identity: str):
+        """Remove an explicit role assignment."""
+        if not self.pool:
+            return
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                f"DELETE FROM {self.user_roles_table_name} WHERE identity = $1",
+                identity
+            )
 
     def _row_to_gateway_dict(self, row) -> dict:
         """Convert a database row to a gateway dict."""

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom'
-import { Settings, PanelLeft } from 'lucide-react'
+import { Settings, PanelLeft, AlertTriangle } from 'lucide-react'
 import Sidebar from './components/layout/Sidebar'
 import GatewayListPage from './components/gateways/GatewayListPage'
 import GatewayDetailPage from './components/gateways/GatewayDetailPage'
@@ -9,6 +9,21 @@ import SettingsPage from './components/settings/SettingsPage'
 import ApiReferencePage from './components/api/ApiReferencePage'
 import McpPage from './components/mcp/McpPage'
 import DebugPage from './components/debug/DebugPage'
+import { api } from './services/api'
+
+function SpFallbackBanner({ onDismiss }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 text-[12px] text-amber-800 dark:text-amber-300">
+      <AlertTriangle size={14} className="flex-shrink-0" />
+      <span>
+        User token passthrough is disabled. Queries use the app's service principal —
+        grant it access to your Genie Spaces and SQL Warehouses.
+        Per-user access controls and lineage are not enforced in this mode.
+      </span>
+      <button onClick={onDismiss} className="ml-auto text-amber-600 dark:text-amber-400 hover:underline flex-shrink-0">dismiss</button>
+    </div>
+  )
+}
 
 function TopBar({ onToggleSidebar }) {
   const navigate = useNavigate()
@@ -38,9 +53,19 @@ function TopBar({ onToggleSidebar }) {
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
+  const [showSpBanner, setShowSpBanner] = useState(false)
+
+  useEffect(() => {
+    api.checkAuthMode()
+      .then(data => {
+        if (data.auth_mode === 'service_principal') setShowSpBanner(true)
+      })
+      .catch(() => {})
+  }, [])
 
   return (
     <div className="flex flex-col h-screen bg-dbx-sidebar">
+      {showSpBanner && <SpFallbackBanner onDismiss={() => setShowSpBanner(false)} />}
       <TopBar onToggleSidebar={() => setSidebarOpen(v => !v)} />
       <div className="flex flex-1 min-h-0">
         <div

--- a/frontend/src/components/gateways/GatewayDetailPage.jsx
+++ b/frontend/src/components/gateways/GatewayDetailPage.jsx
@@ -53,7 +53,8 @@ export default function GatewayDetailPage() {
       setShowDeleteConfirm(false)
       navigate('/')
     } catch (err) {
-      alert('Failed to delete gateway: ' + (err.response?.data?.detail || err.message))
+      setShowDeleteConfirm(false)
+      setError(err.response?.data?.detail || err.message || 'Failed to delete gateway')
     } finally {
       setDeleting(false)
     }

--- a/frontend/src/components/gateways/GatewayDetailPage.jsx
+++ b/frontend/src/components/gateways/GatewayDetailPage.jsx
@@ -3,23 +3,25 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { Trash2, Play, Copy, Loader2, AlertTriangle } from 'lucide-react'
 import { api } from '../../services/api'
 import Modal from '../shared/Modal'
+import { useRole } from '../../context/RoleContext'
 import GatewayOverviewTab from './GatewayOverviewTab'
 import GatewayMetricsTab from './GatewayMetricsTab'
 import GatewayCacheTab from './GatewayCacheTab'
 import GatewayLogsTab from './GatewayLogsTab'
 import GatewaySettingsTab from './GatewaySettingsTab'
 
-const TABS = [
+const ALL_TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'metrics', label: 'Metrics' },
   { id: 'cache', label: 'Cache' },
   { id: 'logs', label: 'Logs' },
-  { id: 'settings', label: 'Settings' },
+  { id: 'settings', label: 'Settings', minRole: 'manage' },
 ]
 
 export default function GatewayDetailPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const { isOwner, isManage } = useRole()
   const [gateway, setGateway] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -64,6 +66,8 @@ export default function GatewayDetailPage() {
   const copyToClipboard = (text) => {
     navigator.clipboard.writeText(text)
   }
+
+  const TABS = ALL_TABS.filter((t) => !t.minRole || isManage)
 
   if (loading) {
     return (
@@ -127,14 +131,16 @@ export default function GatewayDetailPage() {
               <Play size={14} />
               Test in Playground
             </button>
-            <button
-              onClick={() => setShowDeleteConfirm(true)}
-              disabled={deleting}
-              className="inline-flex items-center gap-1.5 h-8 px-3 text-[13px] font-medium text-dbx-text border border-dbx-border-input rounded hover:bg-dbx-neutral-hover transition-colors disabled:opacity-50"
-            >
-              <Trash2 size={14} />
-              {deleting ? 'Deleting...' : 'Delete gateway'}
-            </button>
+            {isOwner && (
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                disabled={deleting}
+                className="inline-flex items-center gap-1.5 h-8 px-3 text-[13px] font-medium text-dbx-text border border-dbx-border-input rounded hover:bg-dbx-neutral-hover transition-colors disabled:opacity-50"
+              >
+                <Trash2 size={14} />
+                {deleting ? 'Deleting...' : 'Delete gateway'}
+              </button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/gateways/GatewayListPage.jsx
+++ b/frontend/src/components/gateways/GatewayListPage.jsx
@@ -6,9 +6,11 @@ import DataTable from '../shared/DataTable'
 import StatusBadge from '../shared/StatusBadge'
 import EmptyState from '../shared/EmptyState'
 import GatewayCreateModal from './GatewayCreateModal'
+import { useRole } from '../../context/RoleContext'
 
 export default function GatewayListPage() {
   const navigate = useNavigate()
+  const { isOwner } = useRole()
   const [gateways, setGateways] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -153,13 +155,15 @@ export default function GatewayListPage() {
             Intelligent caching gateway for Databricks Genie API
           </p>
         </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
-        >
-          <Plus size={16} />
-          Gateway
-        </button>
+        {isOwner && (
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
+          >
+            <Plus size={16} />
+            Gateway
+          </button>
+        )}
       </div>
 
       {/* Search bar */}
@@ -198,7 +202,7 @@ export default function GatewayListPage() {
           icon={Layers}
           title="No gateways yet"
           description="Create a gateway to start caching Genie queries and accelerating your analytics."
-          action={
+          action={isOwner ? (
             <button
               onClick={() => setShowCreate(true)}
               className="flex items-center gap-2 bg-dbx-blue text-white rounded h-9 px-4 text-[13px] font-medium hover:bg-dbx-blue-dark transition-colors"
@@ -206,7 +210,7 @@ export default function GatewayListPage() {
               <Plus size={16} />
               Create your first gateway
             </button>
-          }
+          ) : null}
         />
       ) : (
         <DataTable
@@ -217,12 +221,13 @@ export default function GatewayListPage() {
         />
       )}
 
-      {/* Create modal */}
-      <GatewayCreateModal
-        open={showCreate}
-        onClose={() => setShowCreate(false)}
-        onCreated={handleCreated}
-      />
+      {isOwner && (
+        <GatewayCreateModal
+          open={showCreate}
+          onClose={() => setShowCreate(false)}
+          onCreated={handleCreated}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/gateways/GatewaySettingsTab.jsx
+++ b/frontend/src/components/gateways/GatewaySettingsTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Save, RotateCcw, Loader2 } from 'lucide-react'
+import { Save, RotateCcw, Loader2, AlertTriangle } from 'lucide-react'
 import { api } from '../../services/api'
 
 const secondsToTtl = (seconds) => {
@@ -58,6 +58,7 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
 
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
+  const [saveError, setSaveError] = useState(null)
   const [endpoints, setEndpoints] = useState([])
   const [endpointsLoading, setEndpointsLoading] = useState(true)
   const [warehouses, setWarehouses] = useState([])
@@ -109,7 +110,7 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
       onUpdate?.(updated)
       setSaved(true)
     } catch (err) {
-      alert('Failed to save settings: ' + (err.response?.data?.detail || err.message))
+      setSaveError(err.response?.data?.detail || err.message || 'Failed to save settings')
     } finally {
       setSaving(false)
     }
@@ -155,6 +156,13 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
 
   return (
     <div className="max-w-xl space-y-6">
+      {saveError && (
+        <div className="flex items-center gap-2 p-3 rounded border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 text-[13px] text-red-700 dark:text-red-300">
+          <AlertTriangle size={14} className="flex-shrink-0" />
+          <span>{saveError}</span>
+          <button onClick={() => setSaveError(null)} className="ml-auto hover:underline">dismiss</button>
+        </div>
+      )}
       {/* ── Semantic Cache (top-level toggle) ── */}
       <SettingsField label="Semantic Cache" description="Enable cache lookup and storage for this gateway. When disabled, every query goes directly to Genie.">
         <ToggleSwitch checked={form.caching_enabled} onChange={(v) => handleChange('caching_enabled', v)} />

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2 } from 'lucide-react'
 import { api } from '../../services/api'
 import { useTheme } from '../../context/ThemeContext'
@@ -145,12 +145,13 @@ export default function SettingsPage() {
   const { isOwner, isManage } = useRole()
   const [activeSection, setActiveSection] = useState('general')
 
-  // Users management state (owner only)
+  // Users management state (manage role and above)
   const [users, setUsers] = useState([])
   const [usersLoading, setUsersLoading] = useState(false)
   const [newUserEmail, setNewUserEmail] = useState('')
   const [newUserRole, setNewUserRole] = useState('use')
   const [userSaving, setUserSaving] = useState(false)
+  const usersLoadedRef = useRef(false)
   const [config, setConfig] = useState({
     storage_backend: 'lakebase', lakebase_service_token: '', lakebase_instance_name: '',
     lakebase_catalog: 'default', lakebase_schema: 'public',
@@ -210,24 +211,28 @@ export default function SettingsPage() {
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
 
-  // Load users when manage/owner navigates to users section
+  // Load users once when manage/owner navigates to the users section
   useEffect(() => {
-    if (isManage && activeSection === 'users' && users.length === 0) {
+    if (isManage && activeSection === 'users' && !usersLoadedRef.current) {
+      usersLoadedRef.current = true
       setUsersLoading(true)
       api.listUsers()
         .then(setUsers)
         .catch(() => setUsers([]))
         .finally(() => setUsersLoading(false))
     }
-  }, [isOwner, activeSection])
+  }, [isManage, activeSection])
 
   const handleAddUser = async () => {
     if (!newUserEmail.trim()) return
     setUserSaving(true)
     try {
-      await api.setUserRole(newUserEmail.trim(), newUserRole)
-      const updated = await api.listUsers()
-      setUsers(updated)
+      const saved = await api.setUserRole(newUserEmail.trim(), newUserRole)
+      // Optimistic update — upsert locally using the response, no second round-trip
+      setUsers(prev => {
+        const without = prev.filter(u => u.identity !== saved.identity)
+        return [...without, saved]
+      })
       setNewUserEmail('')
       setNewUserRole('use')
     } catch { /* ignore */ }
@@ -241,7 +246,10 @@ export default function SettingsPage() {
     } catch { /* ignore */ }
   }
 
-  const SIDEBAR = isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE
+  const SIDEBAR = useMemo(
+    () => (isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE),
+    [isManage]
+  )
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2 } from 'lucide-react'
+import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2, AlertTriangle } from 'lucide-react'
 import { api } from '../../services/api'
 import { useTheme } from '../../context/ThemeContext'
 import { useRole } from '../../context/RoleContext'
@@ -148,9 +148,11 @@ export default function SettingsPage() {
   // Users management state (manage role and above)
   const [users, setUsers] = useState([])
   const [usersLoading, setUsersLoading] = useState(false)
+  const [workspaceUsers, setWorkspaceUsers] = useState([])
   const [newUserEmail, setNewUserEmail] = useState('')
   const [newUserRole, setNewUserRole] = useState('use')
   const [userSaving, setUserSaving] = useState(false)
+  const [userError, setUserError] = useState(null)
   const usersLoadedRef = useRef(false)
   const [config, setConfig] = useState({
     storage_backend: 'lakebase', lakebase_service_token: '', lakebase_instance_name: '',
@@ -211,39 +213,46 @@ export default function SettingsPage() {
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
 
-  // Load users once when manage/owner navigates to the users section
+  // Load users + workspace users eagerly on mount when manage/owner
   useEffect(() => {
-    if (isManage && activeSection === 'users' && !usersLoadedRef.current) {
+    if (isManage && !usersLoadedRef.current) {
       usersLoadedRef.current = true
       setUsersLoading(true)
-      api.listUsers()
-        .then(setUsers)
-        .catch(() => setUsers([]))
-        .finally(() => setUsersLoading(false))
+      Promise.all([
+        api.listUsers().catch(() => []),
+        api.listWorkspaceUsers().then(d => d.users || []).catch(() => []),
+      ]).then(([roleUsers, wsUsers]) => {
+        setUsers(roleUsers)
+        setWorkspaceUsers(wsUsers)
+      }).finally(() => setUsersLoading(false))
     }
-  }, [isManage, activeSection])
+  }, [isManage])
 
   const handleAddUser = async () => {
     if (!newUserEmail.trim()) return
     setUserSaving(true)
+    setUserError(null)
     try {
       const saved = await api.setUserRole(newUserEmail.trim(), newUserRole)
-      // Optimistic update — upsert locally using the response, no second round-trip
       setUsers(prev => {
         const without = prev.filter(u => u.identity !== saved.identity)
         return [...without, saved]
       })
       setNewUserEmail('')
       setNewUserRole('use')
-    } catch { /* ignore */ }
-    finally { setUserSaving(false) }
+    } catch (err) {
+      setUserError(err.response?.data?.detail || err.message || 'Failed to assign role')
+    } finally { setUserSaving(false) }
   }
 
   const handleRemoveUser = async (email) => {
+    setUserError(null)
     try {
       await api.deleteUserRole(email)
       setUsers(prev => prev.filter(u => u.identity !== email))
-    } catch { /* ignore */ }
+    } catch (err) {
+      setUserError(err.response?.data?.detail || err.message || 'Failed to remove user')
+    }
   }
 
   const SIDEBAR = useMemo(
@@ -553,6 +562,15 @@ export default function SettingsPage() {
                 </table>
               </div>
 
+              {/* Error banner */}
+              {userError && (
+                <div className="flex items-center gap-2 p-3 rounded border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 text-[13px] text-red-700 dark:text-red-300 mb-3">
+                  <AlertTriangle size={14} className="flex-shrink-0" />
+                  <span>{userError}</span>
+                  <button onClick={() => setUserError(null)} className="ml-auto hover:underline">dismiss</button>
+                </div>
+              )}
+
               {/* User list */}
               {usersLoading ? (
                 <div className="flex items-center gap-2 py-4 text-[13px] text-dbx-text-secondary">
@@ -597,17 +615,44 @@ export default function SettingsPage() {
                 </div>
               )}
 
-              {/* Add user */}
+              {/* Add user — searchable combobox */}
               <div className="flex items-center gap-2">
-                <input
-                  type="email"
-                  placeholder="user@company.com"
-                  value={newUserEmail}
-                  onChange={(e) => setNewUserEmail(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleAddUser()}
-                  className={`${inputClass} flex-1`}
-                  style={{ maxWidth: '260px' }}
-                />
+                <div className="relative flex-1" style={{ maxWidth: '320px' }}>
+                  <input
+                    type="text"
+                    placeholder="Search users or type email..."
+                    value={newUserEmail}
+                    onChange={(e) => setNewUserEmail(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleAddUser()}
+                    className={`${inputClass} w-full`}
+                    autoComplete="off"
+                  />
+                  {newUserEmail.trim() && workspaceUsers.length > 0 && (
+                    (() => {
+                      const q = newUserEmail.toLowerCase()
+                      const matches = workspaceUsers.filter(wu =>
+                        (wu.email.toLowerCase().includes(q) || wu.displayName.toLowerCase().includes(q))
+                        && wu.email.toLowerCase() !== q
+                      ).slice(0, 8)
+                      return matches.length > 0 ? (
+                        <ul className="absolute z-10 left-0 right-0 mt-1 bg-dbx-bg border border-dbx-border rounded shadow-lg max-h-48 overflow-auto">
+                          {matches.map(wu => (
+                            <li
+                              key={wu.email}
+                              onClick={() => setNewUserEmail(wu.email)}
+                              className="px-3 py-1.5 text-[13px] text-dbx-text hover:bg-dbx-neutral-hover cursor-pointer"
+                            >
+                              <span className="font-medium">{wu.displayName}</span>
+                              {wu.displayName !== wu.email && (
+                                <span className="text-dbx-text-secondary ml-1">({wu.email})</span>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null
+                    })()
+                  )}
+                </div>
                 <select
                   value={newUserRole}
                   onChange={(e) => setNewUserRole(e.target.value)}

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette } from 'lucide-react'
+import { Pencil, Eye, EyeOff, Loader2, CheckCircle, XCircle, FlaskConical, Database, SlidersHorizontal, Palette, Users, Trash2 } from 'lucide-react'
 import { api } from '../../services/api'
 import { useTheme } from '../../context/ThemeContext'
+import { useRole } from '../../context/RoleContext'
 
 const secondsToTtl = (seconds) => {
   if (!seconds || seconds === 0) return { value: '0', unit: 'hours' }
@@ -125,7 +126,7 @@ function EndpointSelect({ value, onChange, endpoints, loading, placeholder, filt
 }
 
 /* ── Sidebar structure ── */
-const SIDEBAR = [
+const SIDEBAR_BASE = [
   { category: 'Preferences', icon: Palette, items: [{ id: 'appearance', label: 'Appearance' }] },
   { category: 'Connection', icon: Database, items: [{ id: 'general', label: 'General' }] },
   { category: 'Gateway Defaults', icon: SlidersHorizontal, items: [
@@ -134,11 +135,22 @@ const SIDEBAR = [
     { id: 'ai-pipeline', label: 'AI Pipeline' },
   ]},
 ]
+const SIDEBAR_OWNER = [
+  { category: 'Access Control', icon: Users, items: [{ id: 'users', label: 'Users' }] },
+]
 
 /* ── Main component ── */
 export default function SettingsPage() {
   const { themeMode, setThemeMode } = useTheme()
+  const { isOwner } = useRole()
   const [activeSection, setActiveSection] = useState('general')
+
+  // Users management state (owner only)
+  const [users, setUsers] = useState([])
+  const [usersLoading, setUsersLoading] = useState(false)
+  const [newUserEmail, setNewUserEmail] = useState('')
+  const [newUserRole, setNewUserRole] = useState('use')
+  const [userSaving, setUserSaving] = useState(false)
   const [config, setConfig] = useState({
     storage_backend: 'lakebase', lakebase_service_token: '', lakebase_instance_name: '',
     lakebase_catalog: 'default', lakebase_schema: 'public',
@@ -197,6 +209,39 @@ export default function SettingsPage() {
       .finally(() => setEndpointsLoading(false))
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
+
+  // Load users when owner navigates to users section
+  useEffect(() => {
+    if (isOwner && activeSection === 'users' && users.length === 0) {
+      setUsersLoading(true)
+      api.listUsers()
+        .then(setUsers)
+        .catch(() => setUsers([]))
+        .finally(() => setUsersLoading(false))
+    }
+  }, [isOwner, activeSection])
+
+  const handleAddUser = async () => {
+    if (!newUserEmail.trim()) return
+    setUserSaving(true)
+    try {
+      await api.setUserRole(newUserEmail.trim(), newUserRole)
+      const updated = await api.listUsers()
+      setUsers(updated)
+      setNewUserEmail('')
+      setNewUserRole('use')
+    } catch { /* ignore */ }
+    finally { setUserSaving(false) }
+  }
+
+  const handleRemoveUser = async (email) => {
+    try {
+      await api.deleteUserRole(email)
+      setUsers(prev => prev.filter(u => u.identity !== email))
+    } catch { /* ignore */ }
+  }
+
+  const SIDEBAR = isOwner ? [...SIDEBAR_BASE, ...SIDEBAR_OWNER] : SIDEBAR_BASE
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current
@@ -459,6 +504,122 @@ export default function SettingsPage() {
                 className={inputClass} style={{ width: '80px' }} />
             </FieldRow>
           </div>
+
+          {/* ── Users (owner only) ── */}
+          {isOwner && (
+            <div ref={el => sectionRefs.current['users'] = el} className="mb-10">
+              <h2 className="text-[22px] font-semibold text-dbx-text leading-[28px] pb-3 border-b border-dbx-border">Users</h2>
+
+              <div className="py-4 text-[12px] text-dbx-text-secondary">
+                Workspace admins always have <span className="font-semibold text-dbx-text">Owner</span> access regardless of this list.
+              </div>
+
+              {/* Role matrix */}
+              <div className="mb-6 rounded border border-dbx-border overflow-hidden text-[12px]">
+                <table className="w-full">
+                  <thead>
+                    <tr className="bg-dbx-sidebar text-dbx-text-secondary">
+                      <th className="text-left px-3 py-2 font-medium">Role</th>
+                      <th className="text-left px-3 py-2 font-medium">Query</th>
+                      <th className="text-left px-3 py-2 font-medium">Configure</th>
+                      <th className="text-left px-3 py-2 font-medium">Create/Delete</th>
+                      <th className="text-left px-3 py-2 font-medium">Manage Users</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[
+                      { role: 'use',    q: true,  c: false, cd: false, mu: false },
+                      { role: 'manage', q: true,  c: true,  cd: false, mu: false },
+                      { role: 'owner',  q: true,  c: true,  cd: true,  mu: true  },
+                    ].map(({ role, q, c, cd, mu }) => (
+                      <tr key={role} className="border-t border-dbx-border">
+                        <td className="px-3 py-2 font-medium capitalize text-dbx-text">{role}</td>
+                        {[q, c, cd, mu].map((v, i) => (
+                          <td key={i} className="px-3 py-2">
+                            <span className={v ? 'text-dbx-blue' : 'text-dbx-border-input'}>{v ? '●' : '○'}</span>
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* User list */}
+              {usersLoading ? (
+                <div className="flex items-center gap-2 py-4 text-[13px] text-dbx-text-secondary">
+                  <Loader2 size={14} className="animate-spin" /> Loading users...
+                </div>
+              ) : (
+                <div className="rounded border border-dbx-border overflow-hidden mb-4 text-[13px]">
+                  {users.length === 0 ? (
+                    <div className="px-4 py-6 text-center text-dbx-text-secondary">
+                      No explicit role assignments. Add users below.
+                    </div>
+                  ) : (
+                    <table className="w-full">
+                      <thead>
+                        <tr className="bg-dbx-sidebar text-dbx-text-secondary text-[12px]">
+                          <th className="text-left px-3 py-2 font-medium">User</th>
+                          <th className="text-left px-3 py-2 font-medium">Role</th>
+                          <th className="text-left px-3 py-2 font-medium">Granted by</th>
+                          <th className="px-3 py-2" />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {users.map((u) => (
+                          <tr key={u.identity} className="border-t border-dbx-border">
+                            <td className="px-3 py-2 text-dbx-text">{u.identity}</td>
+                            <td className="px-3 py-2 capitalize text-dbx-text">{u.role}</td>
+                            <td className="px-3 py-2 text-dbx-text-secondary">{u.granted_by || '—'}</td>
+                            <td className="px-3 py-2 text-right">
+                              <button
+                                onClick={() => handleRemoveUser(u.identity)}
+                                className="text-dbx-text-secondary hover:text-red-600 transition-colors p-1"
+                                title="Remove role"
+                              >
+                                <Trash2 size={13} />
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              )}
+
+              {/* Add user */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="email"
+                  placeholder="user@company.com"
+                  value={newUserEmail}
+                  onChange={(e) => setNewUserEmail(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleAddUser()}
+                  className={`${inputClass} flex-1`}
+                  style={{ maxWidth: '260px' }}
+                />
+                <select
+                  value={newUserRole}
+                  onChange={(e) => setNewUserRole(e.target.value)}
+                  className={`${inputClass} bg-dbx-bg`}
+                  style={{ width: '110px' }}
+                >
+                  <option value="use">Use</option>
+                  <option value="manage">Manage</option>
+                  <option value="owner">Owner</option>
+                </select>
+                <button
+                  onClick={handleAddUser}
+                  disabled={userSaving || !newUserEmail.trim()}
+                  className="h-8 px-3 text-[13px] text-white bg-dbx-blue rounded hover:bg-dbx-blue-dark transition-colors disabled:opacity-50"
+                >
+                  {userSaving ? <Loader2 size={13} className="animate-spin" /> : 'Add'}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* ── AI Pipeline ── */}
           <div ref={el => sectionRefs.current['ai-pipeline'] = el} className="mb-10">

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -135,14 +135,14 @@ const SIDEBAR_BASE = [
     { id: 'ai-pipeline', label: 'AI Pipeline' },
   ]},
 ]
-const SIDEBAR_OWNER = [
+const SIDEBAR_MANAGE = [
   { category: 'Access Control', icon: Users, items: [{ id: 'users', label: 'Users' }] },
 ]
 
 /* ── Main component ── */
 export default function SettingsPage() {
   const { themeMode, setThemeMode } = useTheme()
-  const { isOwner } = useRole()
+  const { isOwner, isManage } = useRole()
   const [activeSection, setActiveSection] = useState('general')
 
   // Users management state (owner only)
@@ -210,9 +210,9 @@ export default function SettingsPage() {
     return () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current) }
   }, [])
 
-  // Load users when owner navigates to users section
+  // Load users when manage/owner navigates to users section
   useEffect(() => {
-    if (isOwner && activeSection === 'users' && users.length === 0) {
+    if (isManage && activeSection === 'users' && users.length === 0) {
       setUsersLoading(true)
       api.listUsers()
         .then(setUsers)
@@ -241,7 +241,7 @@ export default function SettingsPage() {
     } catch { /* ignore */ }
   }
 
-  const SIDEBAR = isOwner ? [...SIDEBAR_BASE, ...SIDEBAR_OWNER] : SIDEBAR_BASE
+  const SIDEBAR = isManage ? [...SIDEBAR_BASE, ...SIDEBAR_MANAGE] : SIDEBAR_BASE
 
   const persistSettings = useCallback(async () => {
     const c = configRef.current
@@ -505,8 +505,8 @@ export default function SettingsPage() {
             </FieldRow>
           </div>
 
-          {/* ── Users (owner only) ── */}
-          {isOwner && (
+          {/* ── Users (manage+) ── */}
+          {isManage && (
             <div ref={el => sectionRefs.current['users'] = el} className="mb-10">
               <h2 className="text-[22px] font-semibold text-dbx-text leading-[28px] pb-3 border-b border-dbx-border">Users</h2>
 
@@ -529,7 +529,7 @@ export default function SettingsPage() {
                   <tbody>
                     {[
                       { role: 'use',    q: true,  c: false, cd: false, mu: false },
-                      { role: 'manage', q: true,  c: true,  cd: false, mu: false },
+                      { role: 'manage', q: true,  c: true,  cd: false, mu: true  },
                       { role: 'owner',  q: true,  c: true,  cd: true,  mu: true  },
                     ].map(({ role, q, c, cd, mu }) => (
                       <tr key={role} className="border-t border-dbx-border">

--- a/frontend/src/context/RoleContext.jsx
+++ b/frontend/src/context/RoleContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { api } from '../services/api'
+
+// role: 'owner' | 'manage' | 'use'
+// isOwner:  role === 'owner'
+// isManage: role === 'manage' || role === 'owner'
+
+const RoleContext = createContext({ role: 'use', isOwner: false, isManage: false, loading: true })
+
+export function RoleProvider({ children }) {
+  const [role, setRole] = useState('use')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.getMyRole()
+      .then((data) => setRole(data.role || 'use'))
+      .catch(() => setRole('use'))
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <RoleContext.Provider value={{
+      role,
+      loading,
+      isOwner: role === 'owner',
+      isManage: role === 'manage' || role === 'owner',
+    }}>
+      {children}
+    </RoleContext.Provider>
+  )
+}
+
+export function useRole() {
+  return useContext(RoleContext)
+}

--- a/frontend/src/context/RoleContext.jsx
+++ b/frontend/src/context/RoleContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { api } from '../services/api'
 
 // role: 'owner' | 'manage' | 'use'
@@ -18,13 +18,15 @@ export function RoleProvider({ children }) {
       .finally(() => setLoading(false))
   }, [])
 
+  const value = useMemo(() => ({
+    role,
+    loading,
+    isOwner: role === 'owner',
+    isManage: role === 'manage' || role === 'owner',
+  }), [role, loading])
+
   return (
-    <RoleContext.Provider value={{
-      role,
-      loading,
-      isOwner: role === 'owner',
-      isManage: role === 'manage' || role === 'owner',
-    }}>
+    <RoleContext.Provider value={value}>
       {children}
     </RoleContext.Provider>
   )

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,13 +3,16 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import { ThemeProvider } from './context/ThemeContext.jsx'
+import { RoleProvider } from './context/RoleContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider>
-        <App />
+        <RoleProvider>
+          <App />
+        </RoleProvider>
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -246,6 +246,10 @@ export const api = {
     const response = await axios.get(`${API_BASE_URL}/workspace/serving-endpoints`);
     return response.data;
   },
+  listWorkspaceUsers: async () => {
+    const response = await axios.get(`${API_BASE_URL}/workspace/users`);
+    return response.data;
+  },
   testLakebaseConnection: async () => {
     const response = await axios.post(`${API_BASE_URL}/settings/test-connection`);
     return response.data;
@@ -286,6 +290,12 @@ export const api = {
     } catch {
       return { theme: null, source: 'error' };
     }
+  },
+
+  // Auth mode check (detects SP fallback when token passthrough is disabled)
+  checkAuthMode: async () => {
+    const response = await axios.get(`${API_BASE_URL}/auth/mode`);
+    return response.data;
   },
 
   getConfig: getConfig,

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -259,6 +259,26 @@ export const api = {
     return response.data;
   },
 
+  getMyRole: async () => {
+    const response = await axios.get(`${API_BASE_URL}/users/me`);
+    return response.data; // { identity, role }
+  },
+
+  listUsers: async () => {
+    const response = await axios.get(`${API_BASE_URL}/users`);
+    return response.data; // [{ identity, role, granted_by, granted_at }]
+  },
+
+  setUserRole: async (email, role) => {
+    const response = await axios.post(`${API_BASE_URL}/users/${encodeURIComponent(email)}/role`, { role });
+    return response.data;
+  },
+
+  deleteUserRole: async (email) => {
+    const response = await axios.delete(`${API_BASE_URL}/users/${encodeURIComponent(email)}`);
+    return response.data;
+  },
+
   getWorkspaceAppearance: async () => {
     try {
       const response = await axios.get(`${API_BASE_URL}/workspace-appearance`);


### PR DESCRIPTION
## Summary

- **RBAC** with three roles (`use`, `manage`, `owner`) enforced on API and frontend
- **Graceful degradation** when user token passthrough is disabled (#22):
  - Management (gateways, settings, users) works via `X-Forwarded-Email` identity
  - Queries fall back to app's SP token with clear warning banner
  - Bootstrap admin auto-detected from app creator (no env var needed)
- **Last-owner protection**: cannot downgrade/remove the only owner
- **Workspace users dropdown** with search via SCIM API
- **Inline error banners** replacing all `alert()` calls
- **`/api/auth/mode`** endpoint so frontend detects SP-mode
- **`/api/workspace/users`** endpoint for user discovery

## Auth modes

| Mode | How it works | Per-user ACL? |
|---|---|---|
| **Passthrough** (default) | User token via `X-Forwarded-Access-Token`, SCIM admin auto-detection | Yes |
| **SP fallback** | App's service principal token when passthrough disabled | No — SP needs access to Genie Spaces |

## Files changed (13 files, +292/-50)

### Backend
- `auth_helpers.py` — `resolve_user_token()`: passthrough → Bearer → SP fallback
- `rbac_routes.py` — last-owner protection, `/api/auth/mode`, `granted_by` in response
- `rbac.py` — auto-detect app creator for bootstrap admin
- `gateway_routes.py` — `/api/workspace/users`, discovery uses `resolve_user_token_optional`
- `genie_clone_routes.py` — `_extract_token` uses `resolve_user_token`
- `routes.py` — `submit_query` uses `resolve_user_token`

### Frontend
- `App.jsx` — SP fallback warning banner
- `SettingsPage.jsx` — workspace users dropdown with search, inline error banners, eager data load
- `GatewayDetailPage.jsx` — inline error on delete (replaces alert)
- `GatewaySettingsTab.jsx` — inline error on save (replaces alert)
- `api.js` — `checkAuthMode()`, `listWorkspaceUsers()`

## Test plan

- [ ] Deploy with passthrough **enabled** — RBAC works, SCIM admin detection, user token used for queries
- [ ] Deploy with passthrough **disabled** — SP fallback banner shows, management works via email, queries use SP
- [ ] Try downgrading the only owner → blocked with clear message
- [ ] Workspace users dropdown populates and search filters correctly
- [ ] Error messages show inline (no browser alerts)

Closes #22

This pull request was AI-assisted by Isaac.