### PR TITLE
fix(#26): persist global settings to Lakebase and wire LLM model overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ Each gateway has a detail page with five tabs.
 
 ## Global Settings
 
-Configure once in the **Settings** page. These apply as defaults for all gateways:
+Configure once in the **Settings** page. These are the **defaults for new gateways** and the **runtime fallback** when a gateway leaves a field unset. Each gateway can override any of these in its own Settings tab.
+
+Global settings are persisted to Lakebase (the `global_settings` table in the app's configured schema), so changes survive redeploys, container restarts, and rollbacks. Only the `lakebase_service_token` is session-scoped (kept in memory) since Databricks Apps inject SP credentials at runtime.
 
 ![Settings](docs/screenshots/09-settings.png)
 
@@ -186,7 +188,9 @@ Configure once in the **Settings** page. These apply as defaults for all gateway
 | **Lakebase Service Token** | The app's built-in SP handles authentication automatically — only set this to override |
 | **Embedding Provider** | `databricks` (Foundation Model API) or `local` |
 | **Question Normalization** | LLM rewrites questions before embedding to improve cache hit rate |
+| **Intent Split** | LLM isolates the latest intent in multi-turn conversations |
 | **Cache Validation** | LLM validates cached results are relevant before returning them |
+| **Normalization / Intent Split / Validation Model** | Serving endpoint override for each LLM stage. Leave blank to use `databricks-llama-4-maverick` |
 
 ---
 

--- a/backend/app/api/config_store.py
+++ b/backend/app/api/config_store.py
@@ -1,69 +1,278 @@
 """
 Shared server configuration overrides.
-Both proxy_routes and genie_clone_routes read from here.
-Updated via PUT /api/config.
 
-Config is persisted to /tmp for the lifetime of the running container.
-Credentials (lakebase_service_token) are NOT stored here — they come from:
-  - DATABRICKS_TOKEN env var (auto-injected by Databricks Apps, used for Lakebase)
-  - Databricks Secrets referenced in app.yaml (for production credential management)
+Global settings are persisted to Lakebase (global_settings table) so they
+survive redeploys. A small in-memory cache reflects the last known state
+and is populated at startup via load_global_settings_from_db() and kept
+in sync by update_overrides().
+
+Sensitive keys (lakebase_service_token) are kept in memory only and never
+written to Lakebase — the app always prefers the SP OAuth credentials
+auto-injected into Databricks Apps (DATABRICKS_CLIENT_ID / _SECRET).
 """
 
-import json
 import logging
-import os
-from pathlib import Path
+import re
+from typing import Any, Callable, Optional
+
 from app.config import get_settings
 
 logger = logging.getLogger(__name__)
 _settings = get_settings()
 
-# In-memory overrides
+# In-memory snapshot of overrides (mirrors the Lakebase global_settings table).
 _server_config_overrides: dict = {}
 
-# Non-sensitive config persisted to /tmp (survives within a running instance)
-_CONFIG_FILE = Path(os.getenv("CONFIG_PERSIST_PATH", "/tmp/genie_cache_config.json"))
+# Keys that stay in memory only — never persisted to Lakebase.
+_NON_PERSISTED_KEYS = frozenset({"lakebase_service_token"})
+
+# Tokens that mark a key as credential-bearing. Belt-and-suspenders in case
+# a new secret-ish field is added to the pydantic settings models without also
+# being listed in _NON_PERSISTED_KEYS. `_is_sensitive_key` is the single source
+# of truth for "don't persist to Lakebase" — keep both the allowlist above and
+# the token guard so a missed listing still short-circuits the DB write.
+#
+# Match at underscore-delimited boundaries (start/end of key or between `_`)
+# so "pat" flags "databricks_pat" but not "patch_interval" / "path_prefix",
+# and "key" does not false-positive on "sql_warehouse_id" etc.
+_SENSITIVE_TOKENS = ("token", "secret", "pat", "password", "api_key")
+_SENSITIVE_PATTERN = re.compile(
+    r"(?:^|_)(?:" + "|".join(re.escape(s) for s in _SENSITIVE_TOKENS) + r")(?:$|_)"
+)
 
 
-def _load_persisted_config():
-    """Load non-sensitive config from /tmp on startup."""
+def _is_sensitive_key(key: str) -> bool:
+    """Return True if the key should be kept in memory only (never persisted)."""
+    if key in _NON_PERSISTED_KEYS:
+        return True
+    return bool(_SENSITIVE_PATTERN.search(key.lower()))
+
+# Keys whose empty-string value should clear the override (and the DB row)
+# rather than persist as "". Covers the SP token (sensitive, memory-only) plus
+# the three per-service LLM endpoint overrides: the gateway settings UI sends
+# "" when the user picks the "Use default" option, and we want that to fall
+# back to the module-level default instead of leaving `{"value": ""}` in
+# Lakebase (which would silently pin the gateway to "no endpoint").
+_CLEARABLE_KEYS = frozenset({
+    "lakebase_service_token",
+    "normalization_model",
+    "validation_model",
+    "intent_split_model",
+})
+
+
+def _coerce_bool(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in ("true", "1", "yes", "on")
+    return bool(v)
+
+
+# Typed schema for persisted global settings. Values coming back from JSONB
+# are coerced to the expected Python type on load so a future bad write (or a
+# manual row edit) can't silently flow a string through `or` / numeric compares
+# in downstream code. Unknown keys pass through untouched.
+_SETTING_TYPES: dict[str, Callable[[Any], Any]] = {
+    "similarity_threshold": float,
+    "cache_ttl_hours": float,
+    "max_queries_per_minute": int,
+    "shared_cache": _coerce_bool,
+    "question_normalization_enabled": _coerce_bool,
+    "cache_validation_enabled": _coerce_bool,
+    "intent_split_enabled": _coerce_bool,
+    "caching_enabled": _coerce_bool,
+    "embedding_provider": str,
+    "databricks_embedding_endpoint": str,
+    "normalization_model": str,
+    "validation_model": str,
+    "intent_split_model": str,
+    "sql_warehouse_id": str,
+    "lakebase_instance_name": str,
+    "lakebase_catalog": str,
+    "lakebase_schema": str,
+    "cache_table_name": str,
+    "query_log_table_name": str,
+    "genie_space_id": str,
+    "storage_backend": str,
+}
+
+
+def _coerce_persisted_settings(raw: dict) -> dict:
+    """Coerce each known key to its declared type; pass unknown keys through."""
+    coerced: dict = {}
+    for k, v in raw.items():
+        if v is None:
+            coerced[k] = None
+            continue
+        caster = _SETTING_TYPES.get(k)
+        if caster is None:
+            coerced[k] = v
+            continue
+        try:
+            coerced[k] = caster(v)
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                "Global settings: could not coerce %s=%r to %s (%s); keeping raw",
+                k, v, caster.__name__, e,
+            )
+            coerced[k] = v
+    return coerced
+
+
+async def load_global_settings_from_db() -> None:
+    """Hydrate the in-memory cache from the Lakebase global_settings table.
+
+    Called once during FastAPI lifespan, after storage initialization and
+    BEFORE uvicorn starts serving requests — which is what makes the
+    clear-then-reload pattern below safe. If a future caller invokes this
+    concurrently with `update_overrides`, the cache can briefly reflect only
+    the DB snapshot (losing an in-flight write). That is acceptable for the
+    lifespan hydrate path; do not call from a request handler.
+    """
     try:
-        if _CONFIG_FILE.exists():
-            data = json.loads(_CONFIG_FILE.read_text())
-            _server_config_overrides.update(data)
-            logger.info("Loaded persisted config from %s (%d keys)", _CONFIG_FILE, len(data))
+        import app.services.database as _db
+        if _db.db_service is None:
+            logger.warning("Global settings: storage not initialized, skipping DB hydrate")
+            return
+        persisted = await _db.db_service.get_global_settings()
     except Exception as e:
-        logger.warning("Could not load persisted config: %s", e)
+        logger.warning("Global settings: could not load from Lakebase (%s); using env defaults only", e)
+        return
 
-
-def _save_persisted_config():
-    """Persist non-sensitive config to /tmp."""
-    try:
-        _CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-        # Never write credentials to disk
-        safe = {k: v for k, v in _server_config_overrides.items() if 'token' not in k and 'secret' not in k and 'pat' not in k}
-        _CONFIG_FILE.write_text(json.dumps(safe))
-    except Exception as e:
-        logger.warning("Could not persist config: %s", e)
-
-
-# Load on import
-_load_persisted_config()
+    # Keep non-persisted keys (e.g. session-scoped tokens) intact.
+    for k in list(_server_config_overrides.keys()):
+        if not _is_sensitive_key(k):
+            _server_config_overrides.pop(k, None)
+    _server_config_overrides.update(_coerce_persisted_settings(persisted))
+    logger.info("Global settings loaded from Lakebase (%d keys)", len(persisted))
 
 
 def get_effective_setting(key: str):
-    """Get setting value: override > env/settings default."""
+    """Return the effective value for a setting.
+
+    Precedence: in-memory override (DB-backed) > app.config defaults (env vars).
+    """
     if key in _server_config_overrides:
         return _server_config_overrides[key]
     return getattr(_settings, key, None)
 
 
-def update_overrides(updates: dict):
-    """Apply a batch of config overrides. Credentials are kept in memory only (not written to disk)."""
-    _server_config_overrides.update(updates)
-    _save_persisted_config()
+async def update_overrides(updates: dict, updated_by: Optional[str] = None) -> None:
+    """Apply a batch of setting overrides.
+
+    Non-sensitive keys are upserted into the Lakebase `global_settings` table;
+    sensitive keys (see `_NON_PERSISTED_KEYS`) are kept in memory only.
+
+    The in-memory cache is updated only AFTER the DB write succeeds so the
+    cache never diverges from the persisted state. Sensitive in-memory keys
+    that bypass Lakebase are committed unconditionally (nothing to persist).
+    """
+    if not updates:
+        return
+
+    # Normalize: treat empty strings as a reset for clearable keys
+    normalized: dict = {}
+    clears: list[str] = []
+    for k, v in updates.items():
+        if k in _CLEARABLE_KEYS and v == "":
+            clears.append(k)
+        else:
+            normalized[k] = v
+
+    db_updates = {k: v for k, v in normalized.items() if not _is_sensitive_key(k)}
+    mem_only_updates = {k: v for k, v in normalized.items() if _is_sensitive_key(k)}
+    persisted_clears = [k for k in clears if not _is_sensitive_key(k)]
+    mem_only_clears = [k for k in clears if _is_sensitive_key(k)]
+
+    # Persist to Lakebase first; only touch the in-memory snapshot for keys whose
+    # DB write actually succeeded, so a failed DB op can't leave the cache ahead
+    # of the persisted state (which would "reappear" on restart and confuse the
+    # user). Delete failures downgrade to per-key skips rather than aborting the
+    # whole batch — the successful upserts already cost a DB round-trip.
+    cache_applies: dict = dict(db_updates)
+    cache_clears: list[str] = list(mem_only_clears)
+    if db_updates or persisted_clears:
+        import app.services.database as _db
+        if _db.db_service is None:
+            logger.warning(
+                "Global settings: storage not initialized, skipping DB persist for %s",
+                list(db_updates.keys()) + persisted_clears,
+            )
+            # No DB to write to — don't touch the cache for would-be persisted
+            # keys either, so get_effective_setting keeps returning the old
+            # value (consistent with "DB is source of truth").
+            cache_applies = {}
+        else:
+            if db_updates:
+                try:
+                    await _db.db_service.update_global_settings(db_updates, updated_by)
+                except Exception:
+                    # Upsert failed — don't apply *any* of this batch to the cache.
+                    # executemany is inside a transaction so the DB state is
+                    # unchanged; mirroring that here keeps the invariant.
+                    logger.exception("Global settings: upsert failed for %s", list(db_updates.keys()))
+                    raise
+            for k in persisted_clears:
+                try:
+                    await _db.db_service.delete_global_setting(k)
+                    cache_clears.append(k)
+                except Exception as e:
+                    # Per-key skip: leave the cache value untouched so the next
+                    # read returns the same thing as a cold reload from the DB.
+                    # The already-committed db_updates stay applied in cache.
+                    logger.warning(
+                        "Global settings: delete of %s failed (%s); leaving cache value intact",
+                        k, e,
+                    )
+
+    # DB is consistent — apply only the ops whose DB side actually succeeded.
+    for k in cache_clears:
+        _server_config_overrides.pop(k, None)
+    if cache_applies:
+        _server_config_overrides.update(cache_applies)
+    if mem_only_updates:
+        _server_config_overrides.update(mem_only_updates)
+
+
+def invalidate_key(key: str) -> None:
+    """Remove a key from the in-memory override snapshot.
+
+    Use this from route handlers that delete a persisted setting directly
+    (e.g. DELETE /settings/{key}) so the in-process cache doesn't keep serving
+    a stale value until the next restart.
+    """
+    _server_config_overrides.pop(key, None)
+
+
+async def delete_override(key: str) -> bool:
+    """Delete a persisted override.
+
+    Ordering: DB delete runs first; the in-memory cache is only invalidated
+    AFTER a successful DB delete. This preserves the invariant that the cache
+    never holds a value that the DB does not also hold — on DB failure, both
+    keep the old value; on success, a tiny read-window may see the cached
+    value before invalidation, which is preferable to the opposite case
+    (cache cleared but DB delete failed, causing the key to reappear on
+    restart and confuse the user).
+
+    Sensitive (non-persisted) keys are a pure cache-only operation.
+    """
+    if _is_sensitive_key(key):
+        existed = key in _server_config_overrides
+        _server_config_overrides.pop(key, None)
+        return existed
+
+    import app.services.database as _db
+    if _db.db_service is None:
+        logger.warning("Global settings: storage not initialized, cannot delete %s", key)
+        return False
+
+    deleted = await _db.db_service.delete_global_setting(key)
+    _server_config_overrides.pop(key, None)
+    return deleted
 
 
 def get_overrides() -> dict:
-    """Return current override dict (read-only copy)."""
+    """Return a read-only copy of the current in-memory override snapshot."""
     return dict(_server_config_overrides)

--- a/backend/app/api/gateway_routes.py
+++ b/backend/app/api/gateway_routes.py
@@ -64,6 +64,63 @@ async def list_gateways(req: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _unset_if_blank(body_value):
+    """Normalize blank strings to None so the DB stores NULL.
+
+    _build_runtime_settings then resolves NULL dynamically against the
+    current global setting (and then the env default). Snapshotting globals
+    at create time would silently pin each gateway to whatever global was
+    set at creation and diverge from runtime behavior after a later global
+    change — the banner promise ("runtime fallback when a gateway leaves a
+    field unset") holds only if we leave it unset here.
+    """
+    if body_value is None or body_value == "":
+        return None
+    return body_value
+
+
+def _build_gateway_config_from_body(body: GatewayCreateRequest, user_email: str | None, now: datetime) -> dict:
+    """Translate a gateway-create request body into the storage-layer dict.
+
+    Extracted so the body → config mapping can be unit-tested without
+    dragging in FastAPI, auth, and the DB layer.
+
+    Semantics:
+    - Numeric / boolean fields that are None in the body → stored as NULL
+      (dynamic resolution at runtime).
+    - Text fields: None or "" → stored as NULL, same reason.
+    - sql_warehouse_id has a NOT NULL constraint (pre-existing), so it falls
+      back to the current global at create time and then to empty string.
+      The empty-string fallback lets RuntimeSettings.sql_warehouse_id's
+      .strip() check resolve to the env default.
+    """
+    sql_warehouse_id = body.sql_warehouse_id or get_effective_setting("sql_warehouse_id") or ""
+    return {
+        "id": str(uuid.uuid4()),
+        "name": body.name,
+        "genie_space_id": body.genie_space_id,
+        "sql_warehouse_id": sql_warehouse_id,
+        "similarity_threshold": body.similarity_threshold,
+        "max_queries_per_minute": body.max_queries_per_minute,
+        "cache_ttl_hours": body.cache_ttl_hours,
+        "question_normalization_enabled": body.question_normalization_enabled,
+        "cache_validation_enabled": body.cache_validation_enabled,
+        "caching_enabled": body.caching_enabled,
+        "embedding_provider": _unset_if_blank(body.embedding_provider),
+        "databricks_embedding_endpoint": _unset_if_blank(body.databricks_embedding_endpoint),
+        "shared_cache": body.shared_cache,
+        "normalization_model": _unset_if_blank(body.normalization_model),
+        "validation_model": _unset_if_blank(body.validation_model),
+        "intent_split_model": _unset_if_blank(body.intent_split_model),
+        "intent_split_enabled": body.intent_split_enabled,
+        "status": "active",
+        "created_by": user_email,
+        "description": body.description or "",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
 @gateway_router.post("/gateways", status_code=201)
 async def create_gateway(body: GatewayCreateRequest, req: Request):
     """Create a new gateway configuration. Owner only."""
@@ -77,25 +134,7 @@ async def create_gateway(body: GatewayCreateRequest, req: Request):
         if any(g["name"].lower() == body.name.lower() for g in existing):
             raise HTTPException(status_code=409, detail=f"A gateway named '{body.name}' already exists.")
 
-        config = {
-            "id": str(uuid.uuid4()),
-            "name": body.name,
-            "genie_space_id": body.genie_space_id,
-            "sql_warehouse_id": body.sql_warehouse_id,
-            "similarity_threshold": body.similarity_threshold if body.similarity_threshold is not None else 0.92,
-            "max_queries_per_minute": body.max_queries_per_minute if body.max_queries_per_minute is not None else 5,
-            "cache_ttl_hours": body.cache_ttl_hours if body.cache_ttl_hours is not None else 24,
-            "question_normalization_enabled": body.question_normalization_enabled if body.question_normalization_enabled is not None else False,
-            "cache_validation_enabled": body.cache_validation_enabled if body.cache_validation_enabled is not None else False,
-            "embedding_provider": body.embedding_provider or "databricks",
-            "databricks_embedding_endpoint": body.databricks_embedding_endpoint or "databricks-gte-large-en",
-            "shared_cache": body.shared_cache if body.shared_cache is not None else True,
-            "status": "active",
-            "created_by": user_email,
-            "description": body.description or "",
-            "created_at": now,
-            "updated_at": now,
-        }
+        config = _build_gateway_config_from_body(body, user_email, now)
 
         result = await _db.db_service.create_gateway(config)
         logger.info("Gateway created: id=%s name=%s by=%s", config["id"], config["name"], user_email)
@@ -488,6 +527,8 @@ async def get_settings_endpoint(req: Request):
         "normalization_model": overrides.get("normalization_model", ""),
         "cache_validation_enabled": overrides.get("cache_validation_enabled", True),
         "validation_model": overrides.get("validation_model", ""),
+        "intent_split_enabled": overrides.get("intent_split_enabled", True),
+        "intent_split_model": overrides.get("intent_split_model", ""),
     }
 
 
@@ -526,6 +567,51 @@ async def update_settings_endpoint(body: SettingsUpdateRequest, req: Request):
     if not updated:
         raise HTTPException(status_code=400, detail="No fields to update.")
 
-    update_overrides(batch)
+    user_email = req.headers.get("X-Forwarded-Email")
+    await update_overrides(batch, updated_by=user_email)
     logger.info("Settings updated via gateway API: %s", updated)
     return {"updated": updated, "message": "Settings updated successfully"}
+
+
+# Allowlist of keys accepted by DELETE /settings/{key}. Derived from the same
+# Pydantic model that governs PUT /settings so the two stay in sync. `cache_ttl_seconds`
+# is the PUT alias; the persisted key is `cache_ttl_hours`, so we swap it.
+_DELETABLE_SETTING_KEYS = (
+    set(SettingsUpdateRequest.model_fields.keys()) - {"cache_ttl_seconds"}
+) | {"cache_ttl_hours"}
+
+# Boot-time guard: a future refactor that aliases or drops one of these keys
+# would silently shrink the allowlist and make the corresponding DELETE return
+# 400. Failing at import time surfaces the drift immediately instead of on the
+# first DELETE call from the UI.
+_EXPECTED_DELETABLE_KEYS = {
+    "similarity_threshold", "max_queries_per_minute", "cache_ttl_hours",
+    "question_normalization_enabled", "cache_validation_enabled",
+    "intent_split_enabled", "normalization_model", "validation_model",
+    "intent_split_model", "embedding_provider", "databricks_embedding_endpoint",
+    "shared_cache", "lakebase_service_token",
+}
+_missing = _EXPECTED_DELETABLE_KEYS - _DELETABLE_SETTING_KEYS
+assert not _missing, (
+    f"SettingsUpdateRequest / _DELETABLE_SETTING_KEYS drift: "
+    f"missing expected keys {_missing}. Update one or the other."
+)
+
+
+@gateway_router.delete("/settings/{key}")
+async def delete_setting_endpoint(key: str, req: Request):
+    """Remove a single global setting override. Owner only."""
+    await require_role(req, "owner")
+    if key not in _DELETABLE_SETTING_KEYS:
+        raise HTTPException(status_code=400, detail=f"Unknown setting key: {key}")
+    from app.api.config_store import delete_override
+    try:
+        deleted = await delete_override(key)
+    except Exception as e:
+        logger.exception("Error deleting global setting %s", key)
+        raise HTTPException(status_code=500, detail=str(e))
+    if deleted:
+        logger.info("Global setting deleted: %s", key)
+    else:
+        logger.info("Global setting delete requested but not found: %s", key)
+    return {"key": key, "deleted": deleted}

--- a/backend/app/api/genie_clone_routes.py
+++ b/backend/app/api/genie_clone_routes.py
@@ -123,6 +123,30 @@ async def _resolve_gateway_space_id(space_id: str) -> tuple[str, dict | None]:
     return space_id, None
 
 
+def _coalesce(*values):
+    """Return the first non-None value. Treats 0 and False as valid values
+    (unlike Python's `or`), which is critical for numeric/boolean settings
+    such as cache_ttl_hours=0 or shared_cache=False."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
+def _coalesce_model(*values):
+    """Variant of `_coalesce` for LLM endpoint fields: treats "" as unset.
+
+    Gateway rows may still hold `""` from before `storage_pgvector.update_gateway`
+    started normalizing empty strings to NULL, and `get_effective_setting` can
+    return `""` from a legacy JSONB row. In both cases we want to fall through
+    to the next source rather than send an empty endpoint name to the LLM.
+    """
+    for v in values:
+        if v is not None and v != "":
+            return v
+    return None
+
+
 def _build_runtime_settings(token: str, space_id: str, gateway: dict = None):
     """Build RuntimeSettings using server config overrides (PUT /config) + env defaults.
     If a gateway config is provided, its per-gateway settings override globals.
@@ -135,20 +159,25 @@ def _build_runtime_settings(token: str, space_id: str, gateway: dict = None):
 
     rc = RuntimeConfig(
         genie_space_id=space_id,
-        sql_warehouse_id=gw.get("sql_warehouse_id") or get_effective_setting("sql_warehouse_id") or None,
-        similarity_threshold=gw.get("similarity_threshold") or get_effective_setting("similarity_threshold"),
-        max_queries_per_minute=gw.get("max_queries_per_minute") or get_effective_setting("max_queries_per_minute"),
-        cache_ttl_hours=gw.get("cache_ttl_hours") or get_effective_setting("cache_ttl_hours"),
-        embedding_provider=gw.get("embedding_provider") or get_effective_setting("embedding_provider"),
-        databricks_embedding_endpoint=gw.get("databricks_embedding_endpoint") or get_effective_setting("databricks_embedding_endpoint"),
+        sql_warehouse_id=_coalesce(gw.get("sql_warehouse_id"), get_effective_setting("sql_warehouse_id")),
+        similarity_threshold=_coalesce(gw.get("similarity_threshold"), get_effective_setting("similarity_threshold")),
+        max_queries_per_minute=_coalesce(gw.get("max_queries_per_minute"), get_effective_setting("max_queries_per_minute")),
+        cache_ttl_hours=_coalesce(gw.get("cache_ttl_hours"), get_effective_setting("cache_ttl_hours")),
+        embedding_provider=_coalesce(gw.get("embedding_provider"), get_effective_setting("embedding_provider")),
+        databricks_embedding_endpoint=_coalesce(gw.get("databricks_embedding_endpoint"), get_effective_setting("databricks_embedding_endpoint")),
         storage_backend="lakebase",
-        lakebase_instance_name=get_effective_setting("lakebase_instance_name") or get_effective_setting("lakebase_instance") or None,
+        lakebase_instance_name=_coalesce(get_effective_setting("lakebase_instance_name"), get_effective_setting("lakebase_instance")),
         lakebase_catalog=get_effective_setting("lakebase_catalog") or None,
         lakebase_schema=get_effective_setting("lakebase_schema") or None,
-        cache_table_name=get_effective_setting("cache_table_name") or get_effective_setting("pgvector_table_name") or None,
-        shared_cache=gw.get("shared_cache") if gw.get("shared_cache") is not None else get_effective_setting("shared_cache"),
-        question_normalization_enabled=gw.get("question_normalization_enabled") if gw.get("question_normalization_enabled") is not None else get_effective_setting("question_normalization_enabled"),
-        cache_validation_enabled=gw.get("cache_validation_enabled") if gw.get("cache_validation_enabled") is not None else get_effective_setting("cache_validation_enabled"),
+        cache_table_name=_coalesce(get_effective_setting("cache_table_name"), get_effective_setting("pgvector_table_name")),
+        shared_cache=_coalesce(gw.get("shared_cache"), get_effective_setting("shared_cache")),
+        question_normalization_enabled=_coalesce(gw.get("question_normalization_enabled"), get_effective_setting("question_normalization_enabled")),
+        cache_validation_enabled=_coalesce(gw.get("cache_validation_enabled"), get_effective_setting("cache_validation_enabled")),
+        caching_enabled=_coalesce(gw.get("caching_enabled"), get_effective_setting("caching_enabled")),
+        intent_split_enabled=_coalesce(gw.get("intent_split_enabled"), get_effective_setting("intent_split_enabled")),
+        normalization_model=_coalesce_model(gw.get("normalization_model"), get_effective_setting("normalization_model")),
+        validation_model=_coalesce_model(gw.get("validation_model"), get_effective_setting("validation_model")),
+        intent_split_model=_coalesce_model(gw.get("intent_split_model"), get_effective_setting("intent_split_model")),
     )
     return RuntimeSettings(rc, user_token=token, user_email=None)
 
@@ -426,7 +455,8 @@ async def _handle_query(
     original_query_text = query_text
     space_context = await get_space_context(space_id, rs)
     if rs.question_normalization_enabled:
-        query_text = await split_by_intent(query_text, rs, space_context=space_context)
+        if rs.intent_split_enabled:
+            query_text = await split_by_intent(query_text, rs, space_context=space_context)
         query_text = await normalize_question(query_text, rs, space_context=space_context)
 
     # Generate embedding and check cache

--- a/backend/app/api/proxy_routes.py
+++ b/backend/app/api/proxy_routes.py
@@ -215,7 +215,7 @@ async def proxy_get_config(request: Request):
 
 @proxy_router.put("/config")
 async def proxy_update_config(body: ServerConfigUpdate, request: Request):
-    """Update server configuration (in-memory, persists for app lifetime)."""
+    """Update server configuration (persisted to Lakebase; survives redeploys)."""
     extract_bearer_token(request)
     updated = {}
     batch = {}
@@ -230,7 +230,10 @@ async def proxy_update_config(body: ServerConfigUpdate, request: Request):
     if not updated:
         raise HTTPException(status_code=400, detail="No fields to update. Send at least one field.")
 
-    update_overrides(batch)
+    # Prefer the Databricks-Apps-injected caller email for audit parity with the
+    # UI / gateway endpoints; fall back to "proxy-api" for non-header callers.
+    updated_by = request.headers.get("X-Forwarded-Email") or "proxy-api"
+    await update_overrides(batch, updated_by=updated_by)
 
     logger.info("Config updated via API: %s", updated)
     return {"updated": updated, "message": "Configuration updated successfully"}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -305,6 +305,10 @@ class UIConfigUpdate(BaseModel):
     query_log_table_name: Optional[str] = None
     question_normalization_enabled: Optional[bool] = None
     cache_validation_enabled: Optional[bool] = None
+    intent_split_enabled: Optional[bool] = None
+    normalization_model: Optional[str] = None
+    validation_model: Optional[str] = None
+    intent_split_model: Optional[str] = None
 
 
 @router.get("/config")
@@ -336,6 +340,10 @@ async def get_config(req: Request):
         "lakebase_token_source": "override" if get_effective_setting("lakebase_service_token") else ("auto" if os.getenv("DATABRICKS_CLIENT_ID") else "none"),
         "question_normalization_enabled": overrides.get("question_normalization_enabled", True),
         "cache_validation_enabled": overrides.get("cache_validation_enabled", True),
+        "intent_split_enabled": overrides.get("intent_split_enabled", True),
+        "normalization_model": overrides.get("normalization_model", ""),
+        "validation_model": overrides.get("validation_model", ""),
+        "intent_split_model": overrides.get("intent_split_model", ""),
     }
 
 
@@ -360,7 +368,8 @@ async def put_config(body: UIConfigUpdate, req: Request):
     if not updated:
         raise HTTPException(status_code=400, detail="No fields to update.")
 
-    update_overrides(batch)
+    user_email = req.headers.get("X-Forwarded-Email")
+    await update_overrides(batch, updated_by=user_email)
     logger.info("Config updated via UI: %s", updated)
     return {"updated": updated, "message": "Configuration updated successfully"}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,13 @@ async def lifespan(app: FastAPI):
     from app.services.database import initialize_storage
     storage = await initialize_storage()
 
+    # Hydrate global settings from Lakebase so they survive redeploys
+    try:
+        from app.api.config_store import load_global_settings_from_db
+        await load_global_settings_from_db()
+    except Exception as e:
+        logger.warning("Global settings hydrate failed (continuing with env defaults): %s", e)
+
     # Start periodic JWT refresh for all Lakebase backends
     refresh_task = None
     if settings.storage_backend in ("lakebase", "pgvector") and settings.lakebase_instance:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -26,11 +26,11 @@ class RuntimeConfig(BaseModel):
     max_queries_per_minute: Optional[int] = None
     embedding_provider: Optional[str] = None
     databricks_embedding_endpoint: Optional[str] = None
-    
+
     # Storage backend selection
     storage_backend: Optional[str] = None  # 'lakebase'
     cache_ttl_hours: Optional[float] = None  # 0 = no freshness limit
-    
+
     # Lakebase/PostgreSQL configuration (for PGVector caching)
     lakebase_instance_name: Optional[str] = None  # Lakebase instance name (e.g., my-lakebase-instance)
     lakebase_catalog: Optional[str] = None   # e.g., sean_lakebase_genie
@@ -45,6 +45,12 @@ class RuntimeConfig(BaseModel):
     question_normalization_enabled: Optional[bool] = None  # LLM-based question normalization
     cache_validation_enabled: Optional[bool] = None  # LLM-based cache hit validation
     caching_enabled: Optional[bool] = None  # Enable/disable semantic cache entirely
+    intent_split_enabled: Optional[bool] = None  # LLM-based intent split
+
+    # LLM serving endpoints (per-service overrides; fall back to module default)
+    normalization_model: Optional[str] = None
+    validation_model: Optional[str] = None
+    intent_split_model: Optional[str] = None
 
 class QueryRequest(BaseModel):
     query: str
@@ -166,6 +172,10 @@ class GatewayConfig(BaseModel):
     status: str = "active"
     created_by: Optional[str] = None
     description: str = ""
+    normalization_model: Optional[str] = None
+    validation_model: Optional[str] = None
+    intent_split_model: Optional[str] = None
+    intent_split_enabled: bool = True
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     # Stats (populated on list/get, not stored)
@@ -182,9 +192,14 @@ class GatewayCreateRequest(BaseModel):
     cache_ttl_hours: Optional[float] = None
     question_normalization_enabled: Optional[bool] = None
     cache_validation_enabled: Optional[bool] = None
+    caching_enabled: Optional[bool] = None
     embedding_provider: Optional[str] = None
     databricks_embedding_endpoint: Optional[str] = None
     shared_cache: Optional[bool] = None
+    normalization_model: Optional[str] = None
+    validation_model: Optional[str] = None
+    intent_split_model: Optional[str] = None
+    intent_split_enabled: Optional[bool] = None
     description: Optional[str] = ""
 
 
@@ -202,3 +217,7 @@ class GatewayUpdateRequest(BaseModel):
     sql_warehouse_id: Optional[str] = None
     status: Optional[str] = None
     description: Optional[str] = None
+    normalization_model: Optional[str] = None
+    validation_model: Optional[str] = None
+    intent_split_model: Optional[str] = None
+    intent_split_enabled: Optional[bool] = None

--- a/backend/app/runtime_config.py
+++ b/backend/app/runtime_config.py
@@ -63,12 +63,16 @@ class RuntimeSettings:
 
     @property
     def similarity_threshold(self) -> float:
-        return (self.runtime.similarity_threshold if self.runtime and self.runtime.similarity_threshold
+        # `is not None` — a user-set threshold of 0 is a valid "match everything"
+        # value and must not fall through to the base default.
+        return (self.runtime.similarity_threshold if self.runtime and self.runtime.similarity_threshold is not None
                 else self.base.similarity_threshold)
 
     @property
     def max_queries_per_minute(self) -> int:
-        return (self.runtime.max_queries_per_minute if self.runtime and self.runtime.max_queries_per_minute
+        # `is not None` — 0 is a valid "block all traffic" value for rate limits;
+        # a truthy check would silently replace it with the base default.
+        return (self.runtime.max_queries_per_minute if self.runtime and self.runtime.max_queries_per_minute is not None
                 else self.base.max_queries_per_minute)
 
     @property
@@ -123,6 +127,44 @@ class RuntimeSettings:
             return self.runtime.cache_validation_enabled
         val = get_effective_setting("cache_validation_enabled")
         return val if val is not None else True
+
+    @property
+    def intent_split_enabled(self) -> bool:
+        from app.api.config_store import get_effective_setting
+        if self.runtime and self.runtime.intent_split_enabled is not None:
+            return self.runtime.intent_split_enabled
+        val = get_effective_setting("intent_split_enabled")
+        return val if val is not None else True
+
+    @property
+    def normalization_model(self) -> Optional[str]:
+        return self._resolve_model_field("normalization_model")
+
+    @property
+    def validation_model(self) -> Optional[str]:
+        return self._resolve_model_field("validation_model")
+
+    @property
+    def intent_split_model(self) -> Optional[str]:
+        return self._resolve_model_field("intent_split_model")
+
+    def _resolve_model_field(self, name: str) -> Optional[str]:
+        """Resolve a per-service LLM endpoint override.
+
+        `is not None` + empty-string guard — an empty string is treated as
+        'unset' so the gateway falls through to the global setting. This
+        matches the normalization done at write time in
+        storage_pgvector.update_gateway, and keeps the semantics robust if
+        a legacy row ever holds '' instead of NULL.
+        """
+        from app.api.config_store import get_effective_setting
+        runtime_value = getattr(self.runtime, name, None) if self.runtime else None
+        if runtime_value is not None and runtime_value != "":
+            return runtime_value
+        global_value = get_effective_setting(name)
+        if global_value is not None and global_value != "":
+            return global_value
+        return None
 
     @property
     def full_table_name(self) -> str:

--- a/backend/app/services/cache_validator.py
+++ b/backend/app/services/cache_validator.py
@@ -17,7 +17,8 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-# Databricks Foundation Model endpoint used for validation.
+# Default Databricks Foundation Model endpoint used for validation.
+# Can be overridden per-gateway or globally via RuntimeSettings.validation_model.
 CACHE_VALIDATION_LLM_ENDPOINT = "databricks-llama-4-maverick"
 
 
@@ -40,14 +41,21 @@ def _parse_validation_result(result: dict) -> bool | None:
 
 
 def _get_workspace_client(runtime_settings=None) -> tuple[WorkspaceClient, str]:
-    """Build a WorkspaceClient using user's OAuth token (X-Forwarded-Access-Token)."""
+    """Build a WorkspaceClient using user's OAuth token (X-Forwarded-Access-Token).
+
+    Resolves the serving endpoint from runtime_settings.validation_model if set,
+    else falls back to CACHE_VALIDATION_LLM_ENDPOINT.
+    """
+    endpoint = CACHE_VALIDATION_LLM_ENDPOINT
+    if runtime_settings is not None and getattr(runtime_settings, "validation_model", None):
+        endpoint = runtime_settings.validation_model
     if runtime_settings:
         token = runtime_settings.databricks_token
         if not token:
             raise RuntimeError("No user token available for cache validation (X-Forwarded-Access-Token missing)")
         config = Config(host=runtime_settings.databricks_host, token=token, auth_type="pat")
-        return WorkspaceClient(config=config), CACHE_VALIDATION_LLM_ENDPOINT
-    return WorkspaceClient(), CACHE_VALIDATION_LLM_ENDPOINT
+        return WorkspaceClient(config=config), endpoint
+    return WorkspaceClient(), endpoint
 
 
 async def validate_cache_entry(

--- a/backend/app/services/database.py
+++ b/backend/app/services/database.py
@@ -147,6 +147,17 @@ class DatabaseService:
     async def get_gateway_stats(self, gateway_id: str) -> dict:
         return await self.backend.get_gateway_stats(gateway_id)
 
+    # --- Global settings ---
+
+    async def get_global_settings(self) -> dict:
+        return await self.backend.get_global_settings()
+
+    async def update_global_settings(self, updates: dict, updated_by: Optional[str] = None) -> None:
+        await self.backend.update_global_settings(updates, updated_by)
+
+    async def delete_global_setting(self, key: str) -> bool:
+        return await self.backend.delete_global_setting(key)
+
     # --- User roles ---
 
     async def get_user_role(self, identity: str):

--- a/backend/app/services/intent_splitter.py
+++ b/backend/app/services/intent_splitter.py
@@ -20,6 +20,8 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
+# Default Databricks Foundation Model endpoint used for intent splitting.
+# Can be overridden per-gateway or globally via RuntimeSettings.intent_split_model.
 INTENT_SPLIT_LLM_ENDPOINT = "databricks-llama-4-maverick"
 
 _INTENT_SPLIT_PROMPT_TEMPLATE = """\
@@ -45,7 +47,14 @@ CONVERSATION:
 
 
 def _get_workspace_client(runtime_settings=None) -> tuple[WorkspaceClient, str]:
-    """Build a WorkspaceClient respecting the current auth mode."""
+    """Build a WorkspaceClient respecting the current auth mode.
+
+    Resolves the serving endpoint from runtime_settings.intent_split_model if set,
+    else falls back to INTENT_SPLIT_LLM_ENDPOINT.
+    """
+    endpoint = INTENT_SPLIT_LLM_ENDPOINT
+    if runtime_settings is not None and getattr(runtime_settings, "intent_split_model", None):
+        endpoint = runtime_settings.intent_split_model
     if runtime_settings:
         token = runtime_settings.databricks_token
         if not token:
@@ -54,7 +63,7 @@ def _get_workspace_client(runtime_settings=None) -> tuple[WorkspaceClient, str]:
         client = WorkspaceClient(config=config)
     else:
         client = WorkspaceClient()
-    return client, INTENT_SPLIT_LLM_ENDPOINT
+    return client, endpoint
 
 
 async def split_by_intent(context_text: str, runtime_settings=None, space_context: str = "") -> str:

--- a/backend/app/services/question_normalizer.py
+++ b/backend/app/services/question_normalizer.py
@@ -17,7 +17,8 @@ from app.config import get_settings
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-# Databricks Foundation Model endpoint used for normalization.
+# Default Databricks Foundation Model endpoint used for normalization.
+# Can be overridden per-gateway or globally via RuntimeSettings.normalization_model.
 QUESTION_NORMALIZATION_LLM_ENDPOINT = "databricks-llama-4-maverick"
 
 _NORMALIZATION_PROMPT_TEMPLATE = """\
@@ -44,14 +45,21 @@ QUESTION:
 
 
 def _get_workspace_client(runtime_settings=None) -> tuple[WorkspaceClient, str]:
-    """Build a WorkspaceClient using user's OAuth token (X-Forwarded-Access-Token)."""
+    """Build a WorkspaceClient using user's OAuth token (X-Forwarded-Access-Token).
+
+    Resolves the serving endpoint from runtime_settings.normalization_model if set,
+    else falls back to QUESTION_NORMALIZATION_LLM_ENDPOINT.
+    """
+    endpoint = QUESTION_NORMALIZATION_LLM_ENDPOINT
+    if runtime_settings is not None and getattr(runtime_settings, "normalization_model", None):
+        endpoint = runtime_settings.normalization_model
     if runtime_settings:
         token = runtime_settings.databricks_token
         if not token:
             raise RuntimeError("No user token available for question normalization (X-Forwarded-Access-Token missing)")
         config = Config(host=runtime_settings.databricks_host, token=token, auth_type="pat")
-        return WorkspaceClient(config=config), QUESTION_NORMALIZATION_LLM_ENDPOINT
-    return WorkspaceClient(), QUESTION_NORMALIZATION_LLM_ENDPOINT
+        return WorkspaceClient(config=config), endpoint
+    return WorkspaceClient(), endpoint
 
 
 async def normalize_question(query_text: str, runtime_settings=None, space_context: str = "") -> str:

--- a/backend/app/services/storage_dynamic.py
+++ b/backend/app/services/storage_dynamic.py
@@ -364,6 +364,39 @@ class DynamicStorageService:
             return await backend.get_gateway_stats(gateway_id)
         return backend.get_gateway_stats(gateway_id)
 
+    # --- Global settings CRUD (Lakebase only) ---
+
+    async def get_global_settings(self) -> dict:
+        """Return persisted global settings from the default Lakebase backend."""
+        async def _op():
+            backend = await self._resolve_backend(None)
+            if not hasattr(backend, 'get_global_settings'):
+                return {}
+            return await backend.get_global_settings()
+        return await self._with_reconnect(_op, None)
+
+    async def update_global_settings(self, updates: dict, updated_by: Optional[str] = None) -> None:
+        """Upsert a batch of global settings."""
+        async def _op():
+            backend = await self._resolve_backend(None)
+            if not hasattr(backend, 'update_global_settings'):
+                raise RuntimeError("Global settings require Lakebase backend")
+            await backend.update_global_settings(updates, updated_by)
+        await self._with_reconnect(_op, None)
+
+    async def delete_global_setting(self, key: str) -> bool:
+        """Delete a single global setting row."""
+        async def _op():
+            backend = await self._resolve_backend(None)
+            if not hasattr(backend, 'delete_global_setting'):
+                logger.warning(
+                    "Backend %s does not support delete_global_setting; treating as no-op",
+                    type(backend).__name__,
+                )
+                return False
+            return await backend.delete_global_setting(key)
+        return await self._with_reconnect(_op, None)
+
     # --- User & group roles CRUD (Lakebase only) ---
 
     async def _resolve_rbac_backend(self):

--- a/backend/app/services/storage_pgvector.py
+++ b/backend/app/services/storage_pgvector.py
@@ -75,6 +75,7 @@ class PGVectorStorageService:
         self.query_log_table_name = f"{schema_prefix}.{log_base}"
         self.user_roles_table_name = f"{schema_prefix}.user_roles"
         self.group_roles_table_name = f"{schema_prefix}.group_roles"
+        self.global_settings_table_name = f"{schema_prefix}.global_settings"
 
     def _normalize_table_name(self, table_name: str) -> str:
         """Convert Databricks catalog.schema.table to PostgreSQL schema.table format."""
@@ -199,9 +200,11 @@ class PGVectorStorageService:
             await self._ensure_gateway_table(conn)
             await self._ensure_user_roles_table(conn)
             await self._ensure_group_roles_table(conn)
+            await self._ensure_global_settings_table(conn)
             await self._migrate_genie_space_id_columns(conn)
             await self._migrate_original_query_text(conn)
             await self._migrate_caching_enabled(conn)
+            await self._migrate_gateway_llm_models(conn)
 
     async def _migrate_genie_space_id_columns(self, conn):
         """Migration: ensure both gateway_id and genie_space_id columns exist.
@@ -285,6 +288,29 @@ class PGVectorStorageService:
                 logger.info("Added caching_enabled column to %s", self.gateway_table_name)
         except Exception as e:
             logger.warning("Could not add caching_enabled to %s: %s", self.gateway_table_name, e)
+
+    async def _migrate_gateway_llm_models(self, conn):
+        """Migration: add per-gateway LLM model overrides + intent_split_enabled flag."""
+        parts = self.gateway_table_name.split('.')
+        schema = parts[-2] if len(parts) >= 2 else 'public'
+        tbl = parts[-1]
+        additions = [
+            ("normalization_model", "TEXT"),
+            ("validation_model", "TEXT"),
+            ("intent_split_model", "TEXT"),
+            ("intent_split_enabled", "BOOLEAN DEFAULT true"),
+        ]
+        for column, coltype in additions:
+            try:
+                exists = await conn.fetchval(
+                    "SELECT 1 FROM information_schema.columns WHERE table_schema=$1 AND table_name=$2 AND column_name=$3",
+                    schema, tbl, column
+                )
+                if not exists:
+                    await conn.execute(f'ALTER TABLE {self.gateway_table_name} ADD COLUMN {column} {coltype}')
+                    logger.info("Added %s column to %s", column, self.gateway_table_name)
+            except Exception as e:
+                logger.warning("Could not add %s to %s: %s", column, self.gateway_table_name, e)
 
     async def _build_connection_string_with_creds(self, hostname, quote_plus, uuid):
         """Generate OAuth credentials and build connection string for a Lakebase hostname."""
@@ -521,11 +547,27 @@ class PGVectorStorageService:
                 status TEXT DEFAULT 'active',
                 created_by TEXT,
                 description TEXT DEFAULT '',
+                normalization_model TEXT,
+                validation_model TEXT,
+                intent_split_model TEXT,
+                intent_split_enabled BOOLEAN DEFAULT true,
                 created_at TIMESTAMPTZ DEFAULT NOW(),
                 updated_at TIMESTAMPTZ DEFAULT NOW()
             )
         """)
         logger.info("Gateway table '%s' initialized", self.gateway_table_name)
+
+    async def _ensure_global_settings_table(self, conn):
+        """Create the global_settings table (key/value JSONB) if it does not exist."""
+        await conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.global_settings_table_name} (
+                key TEXT PRIMARY KEY,
+                value JSONB NOT NULL,
+                updated_at TIMESTAMPTZ DEFAULT NOW(),
+                updated_by TEXT
+            )
+        """)
+        logger.info("Global settings table '%s' initialized", self.global_settings_table_name)
 
     async def search_similar_query(
         self,
@@ -857,28 +899,47 @@ class PGVectorStorageService:
     # --- Gateway CRUD ---
 
     async def create_gateway(self, config: dict) -> dict:
-        """Create a new gateway configuration."""
+        """Create a new gateway configuration.
+
+        The (column, value) list is the single source of truth for both the
+        column list and the `$N` placeholder order, so adding a new field only
+        requires one line here instead of keeping three parallel lists in sync.
+        """
         if not self.pool:
             raise RuntimeError("PGVector storage not initialized. Call initialize() first.")
 
+        fields = [
+            ("id", config["id"]),
+            ("name", config["name"]),
+            ("genie_space_id", config["genie_space_id"]),
+            ("sql_warehouse_id", config["sql_warehouse_id"]),
+            ("similarity_threshold", config.get("similarity_threshold", 0.92)),
+            ("max_queries_per_minute", config.get("max_queries_per_minute", 5)),
+            ("cache_ttl_hours", config.get("cache_ttl_hours", 24)),
+            ("question_normalization_enabled", config.get("question_normalization_enabled", False)),
+            ("cache_validation_enabled", config.get("cache_validation_enabled", False)),
+            ("caching_enabled", config.get("caching_enabled", True)),
+            ("embedding_provider", config.get("embedding_provider", "databricks")),
+            ("databricks_embedding_endpoint", config.get("databricks_embedding_endpoint", "databricks-gte-large-en")),
+            ("shared_cache", config.get("shared_cache", True)),
+            ("status", config.get("status", "active")),
+            ("created_by", config.get("created_by")),
+            ("description", config.get("description", "")),
+            ("normalization_model", config.get("normalization_model")),
+            ("validation_model", config.get("validation_model")),
+            ("intent_split_model", config.get("intent_split_model")),
+            ("intent_split_enabled", config.get("intent_split_enabled", True)),
+            ("created_at", config.get("created_at")),
+            ("updated_at", config.get("updated_at")),
+        ]
+        cols = ", ".join(c for c, _ in fields)
+        placeholders = ", ".join(f"${i}" for i in range(1, len(fields) + 1))
+        values = [v for _, v in fields]
+
         async with self.pool.acquire() as conn:
-            await conn.execute(f"""
-                INSERT INTO {self.gateway_table_name}
-                (id, name, genie_space_id, sql_warehouse_id, similarity_threshold,
-                 max_queries_per_minute, cache_ttl_hours, question_normalization_enabled,
-                 cache_validation_enabled, caching_enabled, embedding_provider, databricks_embedding_endpoint,
-                 shared_cache, status, created_by, description, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-            """,
-                config["id"], config["name"], config["genie_space_id"], config["sql_warehouse_id"],
-                config.get("similarity_threshold", 0.92), config.get("max_queries_per_minute", 5),
-                config.get("cache_ttl_hours", 24), config.get("question_normalization_enabled", False),
-                config.get("cache_validation_enabled", False), config.get("caching_enabled", True),
-                config.get("embedding_provider", "databricks"),
-                config.get("databricks_embedding_endpoint", "databricks-gte-large-en"),
-                config.get("shared_cache", True), config.get("status", "active"),
-                config.get("created_by"), config.get("description", ""),
-                config.get("created_at"), config.get("updated_at"),
+            await conn.execute(
+                f"INSERT INTO {self.gateway_table_name} ({cols}) VALUES ({placeholders})",
+                *values,
             )
             logger.info("Gateway created in DB: id=%s name=%s", config["id"], config["name"])
             return config
@@ -893,7 +954,9 @@ class PGVectorStorageService:
                 SELECT id, name, genie_space_id, sql_warehouse_id, similarity_threshold,
                        max_queries_per_minute, cache_ttl_hours, question_normalization_enabled,
                        cache_validation_enabled, caching_enabled, embedding_provider, databricks_embedding_endpoint,
-                       shared_cache, status, created_by, description, created_at, updated_at
+                       shared_cache, status, created_by, description,
+                       normalization_model, validation_model, intent_split_model, intent_split_enabled,
+                       created_at, updated_at
                 FROM {self.gateway_table_name}
                 WHERE id = $1
             """, gateway_id)
@@ -912,16 +975,26 @@ class PGVectorStorageService:
                 SELECT id, name, genie_space_id, sql_warehouse_id, similarity_threshold,
                        max_queries_per_minute, cache_ttl_hours, question_normalization_enabled,
                        cache_validation_enabled, caching_enabled, embedding_provider, databricks_embedding_endpoint,
-                       shared_cache, status, created_by, description, created_at, updated_at
+                       shared_cache, status, created_by, description,
+                       normalization_model, validation_model, intent_split_model, intent_split_enabled,
+                       created_at, updated_at
                 FROM {self.gateway_table_name}
                 ORDER BY created_at DESC
             """)
             return [self._row_to_gateway_dict(row) for row in rows]
 
     async def update_gateway(self, gateway_id: str, updates: dict) -> Optional[dict]:
-        """Update a gateway configuration."""
+        """Update a gateway configuration.
+
+        Nullable TEXT fields (normalization_model, validation_model, intent_split_model)
+        may be set to empty string explicitly to clear the override. Empty strings are
+        normalized to NULL so the runtime fallback (global setting) kicks in.
+        """
         if not self.pool:
             raise RuntimeError("PGVector storage not initialized. Call initialize() first.")
+
+        # Fields whose current value may be intentionally cleared via empty string
+        _clearable_text_fields = {"normalization_model", "validation_model", "intent_split_model"}
 
         # Build dynamic SET clause from provided updates
         allowed_fields = {
@@ -929,15 +1002,22 @@ class PGVectorStorageService:
             "question_normalization_enabled", "cache_validation_enabled", "caching_enabled",
             "embedding_provider", "databricks_embedding_endpoint", "shared_cache", "status", "description",
             "sql_warehouse_id", "genie_space_id",
+            "normalization_model", "validation_model", "intent_split_model", "intent_split_enabled",
         }
         set_parts = []
         params = []
         param_idx = 1
         for key, value in updates.items():
-            if key in allowed_fields and value is not None:
-                set_parts.append(f"{key} = ${param_idx}")
-                params.append(value)
-                param_idx += 1
+            if key not in allowed_fields:
+                continue
+            # Treat empty string as NULL for clearable text fields
+            if key in _clearable_text_fields and value == "":
+                value = None
+            elif value is None:
+                continue
+            set_parts.append(f"{key} = ${param_idx}")
+            params.append(value)
+            param_idx += 1
 
         if not set_parts:
             return await self.get_gateway(gateway_id)
@@ -1003,6 +1083,70 @@ class PGVectorStorageService:
             """, gateway_id) or 0
 
             return {"cache_count": cache_count, "query_count_7d": query_count, "cache_hits_7d": cache_hits}
+
+    # --- Global settings CRUD ---
+
+    async def get_global_settings(self) -> dict:
+        """Return all persisted global settings as a dict."""
+        if not self.pool:
+            raise RuntimeError("PGVector storage not initialized. Call initialize() first.")
+        import json as _json
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"SELECT key, value FROM {self.global_settings_table_name}"
+            )
+        result = {}
+        for r in rows:
+            raw = r["value"]
+            # asyncpg returns JSONB as str when no codec registered; parse defensively
+            if isinstance(raw, (str, bytes, bytearray)):
+                try:
+                    result[r["key"]] = _json.loads(raw)
+                    continue
+                except Exception:
+                    pass
+            result[r["key"]] = raw
+        return result
+
+    async def update_global_settings(self, updates: dict, updated_by: Optional[str] = None) -> None:
+        """Upsert a batch of global settings atomically.
+
+        The batch runs inside a transaction so a mid-batch failure doesn't
+        leave the table with a partial write (which would then diverge from
+        the in-memory cache — config_store updates the cache only after this
+        call returns).
+        """
+        if not self.pool:
+            raise RuntimeError("PGVector storage not initialized. Call initialize() first.")
+        if not updates:
+            return
+        import json as _json
+        rows = [(k, _json.dumps(v), updated_by) for k, v in updates.items()]
+        async with self.pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.executemany(
+                    f"""
+                    INSERT INTO {self.global_settings_table_name} (key, value, updated_at, updated_by)
+                    VALUES ($1, $2::jsonb, NOW(), $3)
+                    ON CONFLICT (key) DO UPDATE
+                      SET value = EXCLUDED.value,
+                          updated_at = NOW(),
+                          updated_by = EXCLUDED.updated_by
+                    """,
+                    rows,
+                )
+        logger.info("Global settings upserted: %s", list(updates.keys()))
+
+    async def delete_global_setting(self, key: str) -> bool:
+        """Remove a global setting. Returns True if a row was deleted."""
+        if not self.pool:
+            raise RuntimeError("PGVector storage not initialized. Call initialize() first.")
+        async with self.pool.acquire() as conn:
+            result = await conn.execute(
+                f"DELETE FROM {self.global_settings_table_name} WHERE key = $1",
+                key,
+            )
+        return result != "DELETE 0"
 
     # --- User roles CRUD ---
 
@@ -1110,6 +1254,7 @@ class PGVectorStorageService:
 
     def _row_to_gateway_dict(self, row) -> dict:
         """Convert a database row to a gateway dict."""
+        keys = row.keys()
         return {
             "id": row["id"],
             "name": row["name"],
@@ -1120,13 +1265,17 @@ class PGVectorStorageService:
             "cache_ttl_hours": row["cache_ttl_hours"],
             "question_normalization_enabled": row["question_normalization_enabled"],
             "cache_validation_enabled": row["cache_validation_enabled"],
-            "caching_enabled": row["caching_enabled"] if "caching_enabled" in row.keys() else True,
+            "caching_enabled": row["caching_enabled"] if "caching_enabled" in keys else True,
             "embedding_provider": row["embedding_provider"],
             "databricks_embedding_endpoint": row["databricks_embedding_endpoint"],
             "shared_cache": row["shared_cache"],
             "status": row["status"],
             "created_by": row["created_by"],
             "description": row["description"],
+            "normalization_model": row["normalization_model"] if "normalization_model" in keys else None,
+            "validation_model": row["validation_model"] if "validation_model" in keys else None,
+            "intent_split_model": row["intent_split_model"] if "intent_split_model" in keys else None,
+            "intent_split_enabled": row["intent_split_enabled"] if "intent_split_enabled" in keys else True,
             "created_at": _to_utc_iso(row["created_at"]),
             "updated_at": _to_utc_iso(row["updated_at"]),
         }

--- a/backend/tests/test_config_store.py
+++ b/backend/tests/test_config_store.py
@@ -1,0 +1,381 @@
+"""
+Tests for app.api.config_store.
+
+Regression coverage for issue #26:
+- _coerce_persisted_settings guards against JSONB type drift so downstream
+  numeric / boolean comparisons never receive a string sentinel.
+- delete_override enforces DB-first ordering: cache is invalidated only
+  AFTER a successful DB delete so a DB failure can't leave the cache in a
+  falsely-empty state.
+"""
+import asyncio
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _run(coro):
+    """Run an async coroutine in a fresh event loop. Avoids the pytest-asyncio dep."""
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture
+def config_store(monkeypatch):
+    """Import app.api.config_store fresh against a stubbed app.config.
+
+    conftest.py ships a lightweight stub of app.api.config_store; we replace
+    it with the real module here and put back any required sibling stubs.
+    """
+    # app.config.get_settings provides the base defaults the module reads at
+    # import time for `_settings`. The real object just needs the attributes
+    # `get_effective_setting` returns as a fallback.
+    base = types.SimpleNamespace(
+        similarity_threshold=0.92,
+        max_queries_per_minute=5,
+        cache_ttl_hours=24.0,
+    )
+    config_stub = types.ModuleType("app.config")
+    config_stub.get_settings = MagicMock(return_value=base)
+    sys.modules["app.config"] = config_stub
+
+    # Drop the conftest-registered stub so importlib loads the real module.
+    sys.modules.pop("app.api.config_store", None)
+    module = importlib.import_module("app.api.config_store")
+    # Ensure app.api exposes the real module as attribute (for patch() paths).
+    sys.modules["app.api"].config_store = module
+
+    # Reset the in-memory override dict between tests
+    module._server_config_overrides.clear()
+    yield module
+
+    # Cleanup: restore the conftest stub so other tests keep working
+    sys.modules.pop("app.api.config_store", None)
+
+
+class TestCoercePersistedSettings:
+    """JSONB can hold any shape. Guard downstream code from type drift."""
+
+    def test_float_from_string(self, config_store):
+        out = config_store._coerce_persisted_settings({"similarity_threshold": "0.85"})
+        assert out["similarity_threshold"] == 0.85
+        assert isinstance(out["similarity_threshold"], float)
+
+    def test_int_from_string(self, config_store):
+        out = config_store._coerce_persisted_settings({"max_queries_per_minute": "42"})
+        assert out["max_queries_per_minute"] == 42
+        assert isinstance(out["max_queries_per_minute"], int)
+
+    def test_bool_from_string_true(self, config_store):
+        for s in ("true", "True", "1", "yes", "on"):
+            out = config_store._coerce_persisted_settings({"shared_cache": s})
+            assert out["shared_cache"] is True, f"{s!r} should coerce to True"
+
+    def test_bool_from_string_false(self, config_store):
+        for s in ("false", "0", "no", "off", ""):
+            out = config_store._coerce_persisted_settings({"shared_cache": s})
+            assert out["shared_cache"] is False, f"{s!r} should coerce to False"
+
+    def test_bool_passthrough(self, config_store):
+        out = config_store._coerce_persisted_settings({"shared_cache": True})
+        assert out["shared_cache"] is True
+
+    def test_none_passes_through(self, config_store):
+        out = config_store._coerce_persisted_settings({"similarity_threshold": None})
+        assert out["similarity_threshold"] is None
+
+    def test_unknown_key_passes_through(self, config_store):
+        out = config_store._coerce_persisted_settings({"future_key": {"nested": "value"}})
+        assert out["future_key"] == {"nested": "value"}
+
+    def test_uncoercible_value_kept_raw(self, config_store):
+        """A bad write is logged but kept — we can't recover the original intent."""
+        out = config_store._coerce_persisted_settings({"max_queries_per_minute": "not-a-number"})
+        # Falls through, raw value retained (downstream may still error, but
+        # that's more useful than silently returning 0)
+        assert out["max_queries_per_minute"] == "not-a-number"
+
+
+class TestGetEffectiveSetting:
+    def test_override_wins_over_env(self, config_store):
+        config_store._server_config_overrides["similarity_threshold"] = 0.5
+        assert config_store.get_effective_setting("similarity_threshold") == 0.5
+
+    def test_env_fallback_when_no_override(self, config_store):
+        # No override — falls through to get_settings() attributes
+        assert config_store.get_effective_setting("similarity_threshold") == 0.92
+
+    def test_missing_key_returns_none(self, config_store):
+        assert config_store.get_effective_setting("nonexistent_key") is None
+
+
+class TestDeleteOverrideOrdering:
+    """Cache is only cleared AFTER a successful DB delete. DB failure must
+    leave the cache untouched so the user sees a consistent state on retry."""
+
+    def test_successful_delete_clears_cache(self, config_store, monkeypatch):
+        config_store._server_config_overrides["similarity_threshold"] = 0.5
+        fake_service = MagicMock()
+        fake_service.delete_global_setting = AsyncMock(return_value=True)
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        deleted = _run(config_store.delete_override("similarity_threshold"))
+
+        assert deleted is True
+        assert "similarity_threshold" not in config_store._server_config_overrides
+        fake_service.delete_global_setting.assert_awaited_once_with("similarity_threshold")
+
+    def test_db_failure_leaves_cache_unchanged(self, config_store, monkeypatch):
+        """If DB delete raises, the cached value must NOT be removed — otherwise
+        a retry would see the cache empty but the DB still holding the value,
+        which causes the key to 'reappear' on restart."""
+        config_store._server_config_overrides["similarity_threshold"] = 0.5
+        fake_service = MagicMock()
+        fake_service.delete_global_setting = AsyncMock(side_effect=RuntimeError("DB down"))
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        with pytest.raises(RuntimeError, match="DB down"):
+            _run(config_store.delete_override("similarity_threshold"))
+
+        assert config_store._server_config_overrides.get("similarity_threshold") == 0.5
+
+    def test_non_persisted_key_is_cache_only(self, config_store, monkeypatch):
+        """Sensitive keys (lakebase_service_token) never touch the DB."""
+        config_store._server_config_overrides["lakebase_service_token"] = "secret"
+        fake_service = MagicMock()
+        fake_service.delete_global_setting = AsyncMock(return_value=True)
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        deleted = _run(config_store.delete_override("lakebase_service_token"))
+
+        assert deleted is True
+        assert "lakebase_service_token" not in config_store._server_config_overrides
+        fake_service.delete_global_setting.assert_not_awaited()
+
+
+class TestUpdateOverridesOrdering:
+    """DB write happens first; cache is only updated after success so a
+    failed DB write can't leave the cache holding a value that will be lost
+    on restart."""
+
+    def test_successful_update_writes_to_cache(self, config_store, monkeypatch):
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock(return_value=None)
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        _run(config_store.update_overrides({"similarity_threshold": 0.8}))
+
+        assert config_store._server_config_overrides["similarity_threshold"] == 0.8
+        fake_service.update_global_settings.assert_awaited_once()
+
+    def test_db_failure_leaves_cache_unchanged(self, config_store, monkeypatch):
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock(side_effect=RuntimeError("DB down"))
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        with pytest.raises(RuntimeError):
+            _run(config_store.update_overrides({"similarity_threshold": 0.8}))
+
+        assert "similarity_threshold" not in config_store._server_config_overrides
+
+    def test_non_persisted_key_bypasses_db(self, config_store, monkeypatch):
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock()
+        # Patch db_service on the real (conftest-stubbed) module so the
+        # `import app.services.database as _db` inside config_store picks it up
+        # (import binds to whatever sys.modules returns, but parent-attribute
+        # lookup also reads `app.services.database`).
+        monkeypatch.setattr(sys.modules["app.services.database"], "db_service", fake_service, raising=False)
+
+        _run(config_store.update_overrides({"lakebase_service_token": "secret"}))
+
+        assert config_store._server_config_overrides["lakebase_service_token"] == "secret"
+        fake_service.update_global_settings.assert_not_awaited()
+
+
+class TestClearableModelFields:
+    """PUT /settings sends `""` when the user picks 'Use default' in the model
+    dropdown. The empty string must route to a DB delete — not an upsert of
+    `{"value": ""}` — so the runtime fallback to the module-level default can
+    actually fire."""
+
+    def test_empty_string_model_clears_from_db_and_cache(self, config_store, monkeypatch):
+        config_store._server_config_overrides["normalization_model"] = "databricks-llama-4"
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock()
+        fake_service.delete_global_setting = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            sys.modules["app.services.database"],
+            "db_service",
+            fake_service,
+            raising=False,
+        )
+
+        _run(config_store.update_overrides({"normalization_model": ""}))
+
+        # The cleared key is removed from the cache…
+        assert "normalization_model" not in config_store._server_config_overrides
+        # …the DB delete ran…
+        fake_service.delete_global_setting.assert_awaited_once_with("normalization_model")
+        # …and we did NOT upsert an empty string as the value.
+        fake_service.update_global_settings.assert_not_awaited()
+
+    def test_all_model_fields_are_clearable(self, config_store):
+        for key in ("normalization_model", "validation_model", "intent_split_model"):
+            assert key in config_store._CLEARABLE_KEYS, f"{key} must be clearable"
+
+
+class TestSensitiveKeyGuard:
+    """_is_sensitive_key is the substring belt-and-suspenders that prevents a
+    future secret-bearing key (e.g. `databricks_pat`, `oauth_token`) from being
+    silently persisted to Lakebase because someone forgot to add it to
+    _NON_PERSISTED_KEYS.
+    """
+
+    def test_explicit_non_persisted_key(self, config_store):
+        assert config_store._is_sensitive_key("lakebase_service_token") is True
+
+    def test_token_substring_caught(self, config_store):
+        for key in ("databricks_token", "oauth_token", "MY_TOKEN"):
+            assert config_store._is_sensitive_key(key) is True, key
+
+    def test_secret_substring_caught(self, config_store):
+        assert config_store._is_sensitive_key("client_secret") is True
+        assert config_store._is_sensitive_key("API_SECRET") is True
+
+    def test_pat_substring_caught(self, config_store):
+        assert config_store._is_sensitive_key("databricks_pat") is True
+
+    def test_password_substring_caught(self, config_store):
+        assert config_store._is_sensitive_key("db_password") is True
+
+    def test_api_key_substring_caught(self, config_store):
+        assert config_store._is_sensitive_key("my_api_key") is True
+
+    def test_nonsensitive_keys_pass(self, config_store):
+        for key in (
+            "similarity_threshold", "max_queries_per_minute", "cache_ttl_hours",
+            "shared_cache", "normalization_model", "validation_model",
+            "lakebase_catalog", "lakebase_schema",
+        ):
+            assert config_store._is_sensitive_key(key) is False, key
+
+    def test_boundary_match_no_false_positive_on_substring(self, config_store):
+        """Regression: the old `"pat" in lowered` check would false-positive on
+        `patch_interval` and `path_prefix`. Boundary matching keeps the guard
+        on real `_pat` tokens while letting unrelated names through."""
+        for key in ("patch_interval", "path_prefix", "pattern_cache", "compatible_mode"):
+            assert config_store._is_sensitive_key(key) is False, (
+                f"{key!r} should not trip the sensitive-key guard — the regex "
+                f"must only match at underscore-delimited boundaries"
+            )
+
+    def test_boundary_match_still_catches_token_at_boundary(self, config_store):
+        """`pat` bounded by `_` or start/end is still flagged."""
+        for key in ("pat", "databricks_pat", "pat_prefix", "my_pat_here"):
+            assert config_store._is_sensitive_key(key) is True, key
+
+    def test_sensitive_substring_key_not_persisted_to_db(self, config_store, monkeypatch):
+        """A key NOT in _NON_PERSISTED_KEYS but matching a sensitive substring
+        must still be kept in memory only. This is the regression guard for
+        the old filter behavior."""
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock()
+        monkeypatch.setattr(
+            sys.modules["app.services.database"], "db_service", fake_service, raising=False,
+        )
+
+        # databricks_pat matches the "pat" substring but is NOT in _NON_PERSISTED_KEYS
+        _run(config_store.update_overrides({"databricks_pat": "dapi-xxx"}))
+
+        assert config_store._server_config_overrides["databricks_pat"] == "dapi-xxx"
+        fake_service.update_global_settings.assert_not_awaited()
+
+
+class TestUpdateOverridesPartialFailure:
+    """The cache must never hold a value that the DB doesn't hold. If an upsert
+    fails the whole batch is rejected; if a single clear fails only that key
+    is skipped — the successful upserts stay in cache."""
+
+    def test_upsert_failure_rejects_entire_batch(self, config_store, monkeypatch):
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock(side_effect=RuntimeError("boom"))
+        fake_service.delete_global_setting = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            sys.modules["app.services.database"], "db_service", fake_service, raising=False,
+        )
+
+        with pytest.raises(RuntimeError):
+            _run(config_store.update_overrides({
+                "similarity_threshold": 0.5,
+                "max_queries_per_minute": 10,
+            }))
+
+        # Neither key made it into the cache — mirrors the transactional
+        # rollback of executemany on the DB side.
+        assert "similarity_threshold" not in config_store._server_config_overrides
+        assert "max_queries_per_minute" not in config_store._server_config_overrides
+
+    def test_clear_failure_keeps_cache_value_but_applies_upserts(self, config_store, monkeypatch):
+        """A partial failure in the clear phase must leave the cleared-but-failed
+        key untouched in the cache (so it stays in sync with the DB, which
+        still holds it), while successful upserts in the same batch still apply."""
+        config_store._server_config_overrides["normalization_model"] = "old-model"
+
+        fake_service = MagicMock()
+        fake_service.update_global_settings = AsyncMock()
+        fake_service.delete_global_setting = AsyncMock(side_effect=RuntimeError("delete failed"))
+        monkeypatch.setattr(
+            sys.modules["app.services.database"], "db_service", fake_service, raising=False,
+        )
+
+        _run(config_store.update_overrides({
+            "similarity_threshold": 0.8,          # upsert — should succeed
+            "normalization_model": "",            # clear — will fail
+        }))
+
+        # Upsert applied, cache reflects DB write.
+        assert config_store._server_config_overrides["similarity_threshold"] == 0.8
+        # Clear failed at DB layer — cache MUST NOT drop the key, else a restart
+        # would reintroduce "old-model" from the DB.
+        assert config_store._server_config_overrides["normalization_model"] == "old-model"
+
+    def test_db_service_missing_skips_cache_for_persisted_keys(self, config_store, monkeypatch):
+        """When storage isn't initialized yet, we must not apply the persisted-
+        key half of the batch to the cache — otherwise the cached value would
+        be lost on restart (no DB row backs it)."""
+        monkeypatch.setattr(
+            sys.modules["app.services.database"], "db_service", None, raising=False,
+        )
+
+        _run(config_store.update_overrides({
+            "similarity_threshold": 0.5,
+            "lakebase_service_token": "secret",
+        }))
+
+        # Sensitive in-memory key still applied (nothing to persist).
+        assert config_store._server_config_overrides["lakebase_service_token"] == "secret"
+        # Persisted key NOT applied — we can't commit to DB, so don't diverge.
+        assert "similarity_threshold" not in config_store._server_config_overrides

--- a/backend/tests/test_gateway_create_semantics.py
+++ b/backend/tests/test_gateway_create_semantics.py
@@ -1,0 +1,280 @@
+"""
+Tests for gateway create body → storage-dict translation.
+
+Issue #26 items 1 & 2: gateway defaults were hard-coded at create time, so a
+later change to a global setting never propagated. The fix leaves NULL for
+every field the user didn't explicitly set; _build_runtime_settings resolves
+NULL dynamically against the current global. These tests lock in the
+"None-in → None-out" invariant so that promise holds.
+"""
+import importlib
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixture: import gateway_routes with the minimum stubs it needs
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def gateway_routes(monkeypatch):
+    """Load app.api.gateway_routes fresh, stubbing its heavyweight deps."""
+    # Stub httpx (imported at module top) and fastapi (also imported there)
+    if "httpx" not in sys.modules:
+        httpx_stub = types.ModuleType("httpx")
+        httpx_stub.AsyncClient = MagicMock()
+        sys.modules["httpx"] = httpx_stub
+
+    if "fastapi" not in sys.modules:
+        fastapi_stub = types.ModuleType("fastapi")
+        fastapi_stub.APIRouter = MagicMock()
+        fastapi_stub.HTTPException = type("HTTPException", (Exception,), {
+            "__init__": lambda self, status_code=500, detail="": setattr(self, "status_code", status_code) or setattr(self, "detail", detail) or None
+        })
+        fastapi_stub.Request = MagicMock()
+        sys.modules["fastapi"] = fastapi_stub
+
+    # Stub pydantic if missing (real models require it)
+    if "pydantic" not in sys.modules:
+        try:
+            import pydantic  # noqa: F401
+        except ImportError:
+            pytest.skip("pydantic not installed")
+
+    # Real GatewayCreateRequest (swap out the conftest stub of app.models)
+    sys.modules.pop("app.models", None)
+    sys.modules.pop("app.api.gateway_routes", None)
+
+    # Ensure app.config and app.auth stubs expose what gateway_routes imports
+    sys.modules["app.config"].get_settings = MagicMock(
+        return_value=types.SimpleNamespace(databricks_host="")
+    )
+    sys.modules["app.auth"].ensure_https = lambda h: h
+
+    # app.api.config_store: get_effective_setting must be controllable.
+    # Other test files may have popped this from sys.modules; re-stub it so
+    # the gateway_routes import finds it.
+    if "app.api.config_store" not in sys.modules:
+        cs_stub = types.ModuleType("app.api.config_store")
+        sys.modules["app.api.config_store"] = cs_stub
+        if "app.api" in sys.modules:
+            sys.modules["app.api"].config_store = cs_stub
+    cs_stub = sys.modules["app.api.config_store"]
+    cs_stub.get_effective_setting = MagicMock(return_value=None)
+    cs_stub.get_overrides = MagicMock(return_value={})
+    cs_stub.update_overrides = MagicMock()
+
+    # auth_helpers (require_role etc.) — unused in the function we're testing
+    ah_stub = types.ModuleType("app.api.auth_helpers")
+    ah_stub.extract_bearer_token_optional = MagicMock()
+    ah_stub.resolve_user_token_optional = MagicMock()
+    ah_stub.require_role = MagicMock()
+    sys.modules["app.api.auth_helpers"] = ah_stub
+    sys.modules["app.api"].auth_helpers = ah_stub
+
+    # Import real models
+    import app.models  # noqa: F401
+
+    module = importlib.import_module("app.api.gateway_routes")
+    return module, cs_stub
+
+
+def _body_kwargs(**overrides):
+    """Minimal valid GatewayCreateRequest kwargs."""
+    base = dict(name="gw1", genie_space_id="space-123")
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# _unset_if_blank helper
+# ---------------------------------------------------------------------------
+
+class TestUnsetIfBlank:
+    def test_none_stays_none(self, gateway_routes):
+        mod, _ = gateway_routes
+        assert mod._unset_if_blank(None) is None
+
+    def test_empty_string_becomes_none(self, gateway_routes):
+        mod, _ = gateway_routes
+        assert mod._unset_if_blank("") is None
+
+    def test_nonblank_string_passes_through(self, gateway_routes):
+        mod, _ = gateway_routes
+        assert mod._unset_if_blank("my-model") == "my-model"
+
+    def test_falsy_nonblank_passes_through(self, gateway_routes):
+        """0 and False are legitimate model-field values in some contexts and
+        shouldn't be nulled by a truthy check."""
+        mod, _ = gateway_routes
+        assert mod._unset_if_blank(0) == 0
+        assert mod._unset_if_blank(False) is False
+
+
+# ---------------------------------------------------------------------------
+# _build_gateway_config_from_body
+# ---------------------------------------------------------------------------
+
+class TestBuildGatewayConfigFromBody:
+    def _build(self, mod, **body_overrides):
+        from app.models import GatewayCreateRequest
+        body = GatewayCreateRequest(**_body_kwargs(**body_overrides))
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        return mod._build_gateway_config_from_body(body, user_email="u@x", now=now)
+
+    def test_unset_numeric_fields_become_none(self, gateway_routes):
+        """A minimal body stores NULL for every optional numeric/boolean.
+        _build_runtime_settings will resolve NULL → current global dynamically."""
+        mod, _ = gateway_routes
+        config = self._build(mod)
+        assert config["similarity_threshold"] is None
+        assert config["max_queries_per_minute"] is None
+        assert config["cache_ttl_hours"] is None
+        assert config["shared_cache"] is None
+        assert config["question_normalization_enabled"] is None
+        assert config["cache_validation_enabled"] is None
+        assert config["caching_enabled"] is None
+        assert config["intent_split_enabled"] is None
+
+    def test_caching_enabled_preserved_when_set(self, gateway_routes):
+        """A user who explicitly disables semantic caching at create time must
+        see that choice land in the DB; the `caching_enabled: False` case is
+        exactly the kind of falsy value that truthy-coalescing would drop."""
+        mod, _ = gateway_routes
+        config_off = self._build(mod, caching_enabled=False)
+        assert config_off["caching_enabled"] is False
+        config_on = self._build(mod, caching_enabled=True)
+        assert config_on["caching_enabled"] is True
+
+    def test_user_set_values_are_preserved(self, gateway_routes):
+        mod, _ = gateway_routes
+        config = self._build(mod, similarity_threshold=0.5, max_queries_per_minute=10,
+                             cache_ttl_hours=48.0, shared_cache=False,
+                             question_normalization_enabled=True, intent_split_enabled=False)
+        assert config["similarity_threshold"] == 0.5
+        assert config["max_queries_per_minute"] == 10
+        assert config["cache_ttl_hours"] == 48.0
+        assert config["shared_cache"] is False
+        assert config["question_normalization_enabled"] is True
+        assert config["intent_split_enabled"] is False
+
+    def test_zero_threshold_preserved_not_nulled(self, gateway_routes):
+        """0.0 is a valid 'match everything' threshold. It must NOT be nulled
+        by a truthy check (this was the item #4b bug for runtime, same trap
+        at create time)."""
+        mod, _ = gateway_routes
+        config = self._build(mod, similarity_threshold=0.0)
+        assert config["similarity_threshold"] == 0.0
+
+    def test_zero_qpm_preserved_not_nulled(self, gateway_routes):
+        mod, _ = gateway_routes
+        config = self._build(mod, max_queries_per_minute=0)
+        assert config["max_queries_per_minute"] == 0
+
+    def test_unset_model_fields_become_none(self, gateway_routes):
+        mod, _ = gateway_routes
+        config = self._build(mod)
+        assert config["normalization_model"] is None
+        assert config["validation_model"] is None
+        assert config["intent_split_model"] is None
+        assert config["embedding_provider"] is None
+        assert config["databricks_embedding_endpoint"] is None
+
+    def test_empty_string_model_fields_become_none(self, gateway_routes):
+        """Empty string from the UI ("no selection") is treated the same as
+        NULL so the runtime fallback to the global kicks in."""
+        mod, _ = gateway_routes
+        config = self._build(mod, normalization_model="", validation_model="",
+                             intent_split_model="")
+        assert config["normalization_model"] is None
+        assert config["validation_model"] is None
+        assert config["intent_split_model"] is None
+
+    def test_user_set_model_fields_preserved(self, gateway_routes):
+        mod, _ = gateway_routes
+        config = self._build(mod, normalization_model="custom-norm",
+                             validation_model="custom-val",
+                             intent_split_model="custom-intent")
+        assert config["normalization_model"] == "custom-norm"
+        assert config["validation_model"] == "custom-val"
+        assert config["intent_split_model"] == "custom-intent"
+
+    def test_sql_warehouse_id_falls_back_to_global(self, gateway_routes):
+        """sql_warehouse_id has a NOT NULL DB constraint, so it's the one
+        field that still snapshots the global at create time."""
+        mod, cs = gateway_routes
+        cs.get_effective_setting.side_effect = lambda k: "global-wh" if k == "sql_warehouse_id" else None
+        config = self._build(mod)
+        assert config["sql_warehouse_id"] == "global-wh"
+
+    def test_sql_warehouse_id_body_wins_over_global(self, gateway_routes):
+        mod, cs = gateway_routes
+        cs.get_effective_setting.side_effect = lambda k: "global-wh" if k == "sql_warehouse_id" else None
+        config = self._build(mod, sql_warehouse_id="body-wh")
+        assert config["sql_warehouse_id"] == "body-wh"
+
+    def test_sql_warehouse_id_empty_when_no_global(self, gateway_routes):
+        """RuntimeSettings.sql_warehouse_id's .strip() check routes empty
+        string through to the env default — no DB constraint violation."""
+        mod, cs = gateway_routes
+        cs.get_effective_setting.return_value = None
+        config = self._build(mod)
+        assert config["sql_warehouse_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# update_gateway empty-string normalization — test the SQL param-build logic
+# ---------------------------------------------------------------------------
+
+class TestUpdateGatewayParamBuild:
+    """storage_pgvector.update_gateway normalizes '' → None for clearable text
+    fields so the runtime fallback to the global kicks in after a user clears
+    a dropdown. We validate the transformation by exercising the same
+    allowlist / clearable-set logic."""
+
+    def test_clearable_fields_empty_string_becomes_none(self):
+        # Replicate the transformation inline; any refactor in the real
+        # update_gateway should either keep this invariant or update this test.
+        clearable = {"normalization_model", "validation_model", "intent_split_model"}
+        allowed = {"name", "similarity_threshold"} | clearable
+
+        updates = {"normalization_model": "", "validation_model": "custom", "name": "x"}
+
+        built = []
+        for key, value in updates.items():
+            if key not in allowed:
+                continue
+            if key in clearable and value == "":
+                value = None
+            elif value is None:
+                continue
+            built.append((key, value))
+
+        as_dict = dict(built)
+        assert as_dict["normalization_model"] is None  # cleared → NULL
+        assert as_dict["validation_model"] == "custom"  # explicit value kept
+        assert as_dict["name"] == "x"
+
+    def test_none_skipped_entirely(self):
+        """A None in updates means 'no change' — the field isn't added to
+        the SET clause (preserves existing DB value)."""
+        clearable = {"normalization_model"}
+        allowed = {"name"} | clearable
+        updates = {"normalization_model": None, "name": "x"}
+
+        built = {}
+        for key, value in updates.items():
+            if key not in allowed:
+                continue
+            if key in clearable and value == "":
+                value = None
+            elif value is None:
+                continue
+            built[key] = value
+
+        assert "normalization_model" not in built
+        assert built["name"] == "x"

--- a/backend/tests/test_runtime_config.py
+++ b/backend/tests/test_runtime_config.py
@@ -1,0 +1,243 @@
+"""
+Unit tests for RuntimeSettings fallback semantics.
+
+Regression coverage for issue #26: numeric override fields (similarity_threshold,
+max_queries_per_minute, cache_ttl_hours) must use `is not None` not truthy checks,
+so a user-provided 0 is preserved rather than silently replaced by the base default.
+
+conftest.py stubs out app.runtime_config for other tests; we reload the real
+module here against a lightweight app.config / app.models shim so the real
+property logic under test runs end-to-end.
+"""
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def runtime_config_module():
+    """Load the real app.runtime_config with a minimal app.config / app.models stub."""
+    # app.config.get_settings() — provide defaults the real module reads at import time.
+    base = types.SimpleNamespace(
+        databricks_host="https://example.cloud.databricks.com",
+        genie_space_id="",
+        sql_warehouse_id="",
+        similarity_threshold=0.92,
+        max_queries_per_minute=5,
+        cache_ttl_hours=24.0,
+        embedding_provider="databricks",
+        databricks_embedding_endpoint="databricks-gte-large-en",
+        app_env="test",
+        storage_backend="pgvector",
+        is_databricks=False,
+        shared_cache=True,
+        lakebase_catalog="default",
+        lakebase_schema="public",
+        pgvector_table_name="cached_queries",
+        postgres_connection_string="",
+    )
+    config_stub = types.ModuleType("app.config")
+    config_stub.get_settings = MagicMock(return_value=base)
+    sys.modules["app.config"] = config_stub
+
+    # app.models.RuntimeConfig — use a minimal dataclass-like stand-in. The
+    # real module only reads attributes off the object.
+    class _RuntimeConfig(types.SimpleNamespace):
+        pass
+    models_stub = types.ModuleType("app.models")
+    models_stub.RuntimeConfig = _RuntimeConfig
+    sys.modules["app.models"] = models_stub
+
+    # Force a fresh import of the real runtime_config
+    sys.modules.pop("app.runtime_config", None)
+    module = importlib.import_module("app.runtime_config")
+    importlib.reload(module)
+
+    yield module, _RuntimeConfig, base
+
+
+def _build_rc(RuntimeConfig, **overrides):
+    """Build a RuntimeConfig with only the fields we care about set."""
+    defaults = dict(
+        gateway_id=None,
+        genie_space_id=None,
+        sql_warehouse_id=None,
+        similarity_threshold=None,
+        max_queries_per_minute=None,
+        embedding_provider=None,
+        databricks_embedding_endpoint=None,
+        storage_backend=None,
+        cache_ttl_hours=None,
+        lakebase_instance_name=None,
+        lakebase_catalog=None,
+        lakebase_schema=None,
+        cache_table_name=None,
+        query_log_table_name=None,
+        shared_cache=None,
+        question_normalization_enabled=None,
+        cache_validation_enabled=None,
+        caching_enabled=None,
+        intent_split_enabled=None,
+        normalization_model=None,
+        validation_model=None,
+        intent_split_model=None,
+    )
+    defaults.update(overrides)
+    return RuntimeConfig(**defaults)
+
+
+class TestNumericFallback:
+    """Issue #26: numeric fields must preserve user-set 0, not fall through."""
+
+    def test_similarity_threshold_zero_is_preserved(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, similarity_threshold=0.0), user_token="t")
+        assert rs.similarity_threshold == 0.0, (
+            "similarity_threshold=0 was dropped — a user-set 'match everything' "
+            "threshold must not fall through to base default"
+        )
+
+    def test_similarity_threshold_none_falls_through(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, similarity_threshold=None), user_token="t")
+        assert rs.similarity_threshold == base.similarity_threshold
+
+    def test_similarity_threshold_nonzero_is_preserved(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, similarity_threshold=0.7), user_token="t")
+        assert rs.similarity_threshold == 0.7
+
+    def test_max_queries_per_minute_zero_is_preserved(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, max_queries_per_minute=0), user_token="t")
+        assert rs.max_queries_per_minute == 0, (
+            "max_queries_per_minute=0 was dropped — a user-set 'block all traffic' "
+            "rate limit must not fall through to base default"
+        )
+
+    def test_max_queries_per_minute_none_falls_through(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, max_queries_per_minute=None), user_token="t")
+        assert rs.max_queries_per_minute == base.max_queries_per_minute
+
+    def test_cache_ttl_zero_is_preserved(self, runtime_config_module):
+        """cache_ttl_hours=0 means 'unlimited' per storage_pgvector — must not fall through."""
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, cache_ttl_hours=0.0), user_token="t")
+        assert rs.cache_ttl_hours == 0.0
+
+    def test_cache_ttl_none_falls_through(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, cache_ttl_hours=None), user_token="t")
+        assert rs.cache_ttl_hours == base.cache_ttl_hours
+
+
+class TestBooleanFallback:
+    """Boolean fields were already using `is not None` — lock that behavior in."""
+
+    def test_shared_cache_false_is_preserved(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, shared_cache=False), user_token="t")
+        assert rs.shared_cache is False
+
+    def test_shared_cache_none_falls_through(self, runtime_config_module):
+        module, RC, base = runtime_config_module
+        rs = module.RuntimeSettings(_build_rc(RC, shared_cache=None), user_token="t")
+        assert rs.shared_cache is base.shared_cache
+
+
+class TestModelFieldFallback:
+    """Issue #26: per-service LLM endpoint overrides must:
+    - Prefer runtime (gateway) value when set
+    - Treat empty string as 'unset' (matches update_gateway's "" → NULL normalization)
+    - Fall through to global (config_store.get_effective_setting) when runtime is None/""
+    - Fall through to None when neither is set
+    """
+
+    def _patch_global(self, module, monkeypatch, **kv):
+        """Override get_effective_setting's return value for specific keys.
+
+        Ensures app.api.config_store is registered in sys.modules before
+        patching — other tests (test_config_store) remove it during teardown,
+        so the module may be absent depending on test order.
+        """
+        if "app.api.config_store" not in sys.modules:
+            cs_stub = types.ModuleType("app.api.config_store")
+            cs_stub.get_effective_setting = lambda _k: None
+            sys.modules["app.api.config_store"] = cs_stub
+            if "app.api" in sys.modules:
+                sys.modules["app.api"].config_store = cs_stub
+        def _fake(key):
+            return kv.get(key)
+        monkeypatch.setitem(
+            sys.modules["app.api.config_store"].__dict__,
+            "get_effective_setting",
+            _fake,
+        )
+
+    def test_normalization_model_runtime_wins(self, runtime_config_module, monkeypatch):
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, normalization_model="global-model")
+        rs = module.RuntimeSettings(
+            _build_rc(RC, normalization_model="runtime-model"), user_token="t"
+        )
+        assert rs.normalization_model == "runtime-model"
+
+    def test_normalization_model_empty_string_falls_through(self, runtime_config_module, monkeypatch):
+        """Empty string must be treated as unset (gateway cleared the override)."""
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, normalization_model="global-model")
+        rs = module.RuntimeSettings(
+            _build_rc(RC, normalization_model=""), user_token="t"
+        )
+        assert rs.normalization_model == "global-model"
+
+    def test_normalization_model_none_falls_through(self, runtime_config_module, monkeypatch):
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, normalization_model="global-model")
+        rs = module.RuntimeSettings(
+            _build_rc(RC, normalization_model=None), user_token="t"
+        )
+        assert rs.normalization_model == "global-model"
+
+    def test_normalization_model_no_global_returns_none(self, runtime_config_module, monkeypatch):
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch)  # no globals set
+        rs = module.RuntimeSettings(
+            _build_rc(RC, normalization_model=None), user_token="t"
+        )
+        assert rs.normalization_model is None
+
+    def test_normalization_model_empty_global_returns_none(self, runtime_config_module, monkeypatch):
+        """Global stored as empty string must not be returned as a valid endpoint."""
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, normalization_model="")
+        rs = module.RuntimeSettings(
+            _build_rc(RC, normalization_model=None), user_token="t"
+        )
+        assert rs.normalization_model is None
+
+    def test_validation_model_resolves_like_normalization(self, runtime_config_module, monkeypatch):
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, validation_model="global-val")
+        rs_runtime = module.RuntimeSettings(
+            _build_rc(RC, validation_model="runtime-val"), user_token="t"
+        )
+        rs_empty = module.RuntimeSettings(_build_rc(RC, validation_model=""), user_token="t")
+        rs_none = module.RuntimeSettings(_build_rc(RC, validation_model=None), user_token="t")
+        assert rs_runtime.validation_model == "runtime-val"
+        assert rs_empty.validation_model == "global-val"
+        assert rs_none.validation_model == "global-val"
+
+    def test_intent_split_model_resolves_like_normalization(self, runtime_config_module, monkeypatch):
+        module, RC, base = runtime_config_module
+        self._patch_global(module, monkeypatch, intent_split_model="global-intent")
+        rs_runtime = module.RuntimeSettings(
+            _build_rc(RC, intent_split_model="runtime-intent"), user_token="t"
+        )
+        rs_empty = module.RuntimeSettings(_build_rc(RC, intent_split_model=""), user_token="t")
+        assert rs_runtime.intent_split_model == "runtime-intent"
+        assert rs_empty.intent_split_model == "global-intent"

--- a/backend/tests/test_service_endpoint_resolution.py
+++ b/backend/tests/test_service_endpoint_resolution.py
@@ -1,0 +1,121 @@
+"""
+Tests for per-service LLM endpoint resolution.
+
+Issue #26 item 3: the UI's normalization_model / validation_model /
+intent_split_model dropdowns were ignored because each service hard-coded its
+endpoint. The fix threads runtime_settings.*_model through each service's
+`_get_workspace_client()` as the endpoint name. These tests lock that in so a
+future refactor can't silently break the wiring again.
+"""
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: stub databricks.sdk.core.Config (conftest only stubs
+# databricks.sdk) and make WorkspaceClient a no-op callable so importing the
+# services doesn't require the real SDK.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _stub_sdk():
+    databricks = sys.modules.setdefault("databricks", types.ModuleType("databricks"))
+    sdk = types.ModuleType("databricks.sdk")
+    sdk.WorkspaceClient = MagicMock(return_value=MagicMock(name="ws_client"))
+    sdk_core = types.ModuleType("databricks.sdk.core")
+    sdk_core.Config = MagicMock(return_value=MagicMock(name="sdk_config"))
+    databricks.sdk = sdk
+    sys.modules["databricks"] = databricks
+    sys.modules["databricks.sdk"] = sdk
+    sys.modules["databricks.sdk.core"] = sdk_core
+
+    # Make sure app.config stub has the attributes the service imports at load
+    sys.modules["app.config"].get_settings = MagicMock(
+        return_value=types.SimpleNamespace(databricks_host="https://example.cloud.databricks.com")
+    )
+    yield
+
+
+def _fresh_import(name: str):
+    """Import a fresh copy of a service module."""
+    sys.modules.pop(name, None)
+    return importlib.import_module(name)
+
+
+def _rs(model_attr: str, model_value, *, token="t", host="https://h"):
+    """Build a minimal runtime_settings stand-in exposing one model field."""
+    ns = types.SimpleNamespace(databricks_token=token, databricks_host=host)
+    setattr(ns, model_attr, model_value)
+    return ns
+
+
+# ---------------------------------------------------------------------------
+# question_normalizer
+# ---------------------------------------------------------------------------
+
+class TestQuestionNormalizerEndpoint:
+    def test_uses_runtime_model_when_set(self):
+        mod = _fresh_import("app.services.question_normalizer")
+        _, endpoint = mod._get_workspace_client(_rs("normalization_model", "my-custom-model"))
+        assert endpoint == "my-custom-model"
+
+    def test_falls_back_to_default_when_runtime_none(self):
+        mod = _fresh_import("app.services.question_normalizer")
+        _, endpoint = mod._get_workspace_client(_rs("normalization_model", None))
+        assert endpoint == mod.QUESTION_NORMALIZATION_LLM_ENDPOINT
+
+    def test_falls_back_to_default_when_runtime_empty(self):
+        mod = _fresh_import("app.services.question_normalizer")
+        _, endpoint = mod._get_workspace_client(_rs("normalization_model", ""))
+        assert endpoint == mod.QUESTION_NORMALIZATION_LLM_ENDPOINT
+
+    def test_default_when_runtime_settings_is_none(self):
+        mod = _fresh_import("app.services.question_normalizer")
+        _, endpoint = mod._get_workspace_client(None)
+        assert endpoint == mod.QUESTION_NORMALIZATION_LLM_ENDPOINT
+
+
+# ---------------------------------------------------------------------------
+# cache_validator
+# ---------------------------------------------------------------------------
+
+class TestCacheValidatorEndpoint:
+    def test_uses_runtime_model_when_set(self):
+        mod = _fresh_import("app.services.cache_validator")
+        _, endpoint = mod._get_workspace_client(_rs("validation_model", "custom-validator"))
+        assert endpoint == "custom-validator"
+
+    def test_falls_back_to_default_when_runtime_none(self):
+        mod = _fresh_import("app.services.cache_validator")
+        _, endpoint = mod._get_workspace_client(_rs("validation_model", None))
+        assert endpoint == mod.CACHE_VALIDATION_LLM_ENDPOINT
+
+    def test_default_when_runtime_settings_is_none(self):
+        mod = _fresh_import("app.services.cache_validator")
+        _, endpoint = mod._get_workspace_client(None)
+        assert endpoint == mod.CACHE_VALIDATION_LLM_ENDPOINT
+
+
+# ---------------------------------------------------------------------------
+# intent_splitter
+# ---------------------------------------------------------------------------
+
+class TestIntentSplitterEndpoint:
+    def test_uses_runtime_model_when_set(self):
+        mod = _fresh_import("app.services.intent_splitter")
+        _, endpoint = mod._get_workspace_client(_rs("intent_split_model", "custom-intent"))
+        assert endpoint == "custom-intent"
+
+    def test_falls_back_to_default_when_runtime_none(self):
+        mod = _fresh_import("app.services.intent_splitter")
+        _, endpoint = mod._get_workspace_client(_rs("intent_split_model", None))
+        assert endpoint == mod.INTENT_SPLIT_LLM_ENDPOINT
+
+    def test_default_when_runtime_settings_is_none(self):
+        mod = _fresh_import("app.services.intent_splitter")
+        _, endpoint = mod._get_workspace_client(None)
+        assert endpoint == mod.INTENT_SPLIT_LLM_ENDPOINT

--- a/frontend/src/components/gateways/GatewaySettingsTab.jsx
+++ b/frontend/src/components/gateways/GatewaySettingsTab.jsx
@@ -50,11 +50,14 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
     normalization_model: gateway.normalization_model || '',
     cache_validation_enabled: gateway.cache_validation_enabled !== false,
     validation_model: gateway.validation_model || '',
+    intent_split_enabled: gateway.intent_split_enabled !== false,
+    intent_split_model: gateway.intent_split_model || '',
     embedding_provider: gateway.embedding_provider || 'databricks',
     databricks_embedding_endpoint: gateway.databricks_embedding_endpoint || 'databricks-gte-large-en',
     shared_cache: gateway.shared_cache !== false,
     sql_warehouse_id: gateway.sql_warehouse_id || '',
   })
+  const [globalDefaults, setGlobalDefaults] = useState(null)
 
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -74,6 +77,9 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
       .then((data) => setWarehouses(data.warehouses || []))
       .catch(() => setWarehouses([]))
       .finally(() => setWarehousesLoading(false))
+
+    // Fetch global defaults so the UI can hint what an "empty" field falls back to
+    api.getSettings().then(setGlobalDefaults).catch(() => setGlobalDefaults(null))
   }, [])
 
   useEffect(() => {
@@ -92,16 +98,22 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
     try {
       setSaveError(null)
       setSaving(true)
+      // Preserve user-set 0 (valid "match everything" / "block all traffic");
+      // NaN (empty input) falls through to the undefined backend default.
+      const threshold = parseFloat(form.similarity_threshold)
+      const qpm = parseInt(form.max_queries_per_minute)
       const updates = {
         caching_enabled: form.caching_enabled,
-        similarity_threshold: parseFloat(form.similarity_threshold) || 0.92,
+        similarity_threshold: Number.isFinite(threshold) ? threshold : undefined,
         cache_ttl_seconds: ttlToSeconds(form.cache_ttl_value, form.cache_ttl_unit),
-        max_qpm: parseInt(form.max_queries_per_minute) || 5,
-        max_queries_per_minute: parseInt(form.max_queries_per_minute) || 5,
+        max_qpm: Number.isFinite(qpm) ? qpm : undefined,
+        max_queries_per_minute: Number.isFinite(qpm) ? qpm : undefined,
         question_normalization_enabled: form.question_normalization_enabled,
-        normalization_model: form.normalization_model || undefined,
+        normalization_model: form.normalization_model ?? '',
         cache_validation_enabled: form.cache_validation_enabled,
-        validation_model: form.validation_model || undefined,
+        validation_model: form.validation_model ?? '',
+        intent_split_enabled: form.intent_split_enabled,
+        intent_split_model: form.intent_split_model ?? '',
         embedding_provider: form.embedding_provider,
         databricks_embedding_endpoint: form.databricks_embedding_endpoint,
         shared_cache: form.shared_cache,
@@ -120,24 +132,28 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
   const handleResetDefaults = async () => {
     try {
       const defaults = await api.getSettings().catch(() => null)
-      setForm({
+      setForm((prev) => ({
+        ...prev,
+        caching_enabled: defaults?.caching_enabled ?? true,
         similarity_threshold: String(defaults?.similarity_threshold ?? 0.92),
         cache_ttl_value: '24',
         cache_ttl_unit: 'hours',
         max_queries_per_minute: String(defaults?.max_queries_per_minute ?? 5),
         question_normalization_enabled: defaults?.question_normalization_enabled ?? true,
-        normalization_model: defaults?.normalization_model || '',
+        normalization_model: '',
         cache_validation_enabled: defaults?.cache_validation_enabled ?? true,
-        validation_model: defaults?.validation_model || '',
+        validation_model: '',
+        intent_split_enabled: defaults?.intent_split_enabled ?? true,
+        intent_split_model: '',
         embedding_provider: defaults?.embedding_provider ?? 'databricks',
         databricks_embedding_endpoint: defaults?.databricks_embedding_endpoint ?? 'databricks-gte-large-en',
         shared_cache: defaults?.shared_cache ?? true,
-        sql_warehouse_id: form.sql_warehouse_id,
-      })
+      }))
       setSaved(false)
     } catch {
       setForm(prev => ({
         ...prev,
+        caching_enabled: true,
         similarity_threshold: '0.92',
         cache_ttl_value: '24',
         cache_ttl_unit: 'hours',
@@ -146,6 +162,8 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
         normalization_model: '',
         cache_validation_enabled: true,
         validation_model: '',
+        intent_split_enabled: true,
+        intent_split_model: '',
         embedding_provider: 'databricks',
         databricks_embedding_endpoint: 'databricks-gte-large-en',
         shared_cache: true,
@@ -155,8 +173,19 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
 
   const inputClass = 'h-8 w-full border border-dbx-border-input rounded px-3 text-[13px] text-dbx-text bg-dbx-bg outline-none focus:border-dbx-blue transition-colors'
 
+  const globalHint = (key, formatter = (v) => v) => {
+    if (!globalDefaults) return null
+    const v = globalDefaults[key]
+    if (v === undefined || v === null || v === '') return null
+    return <span className="text-[12px] text-dbx-text-secondary ml-2">global: {formatter(v)}</span>
+  }
+
   return (
     <div className="max-w-xl space-y-6">
+      <div className="px-3 py-2 rounded bg-dbx-neutral-hover border border-dbx-border text-[12px] text-dbx-text-secondary">
+        Per-gateway settings override the global defaults (Settings page). Leave a model field blank to inherit from global.
+      </div>
+
       {/* ── Semantic Cache (top-level toggle) ── */}
       <SettingsField label="Semantic Cache" description="Enable cache lookup and storage for this gateway. When disabled, every query goes directly to Genie.">
         <ToggleSwitch checked={form.caching_enabled} onChange={(v) => handleChange('caching_enabled', v)} />
@@ -190,11 +219,24 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
                 onChange={(v) => handleChange('question_normalization_enabled', v)} />
             </SettingsField>
             {form.question_normalization_enabled && (
-              <SettingsField label="Normalization Model" description="LLM endpoint for normalization">
-                <EndpointSelect value={form.normalization_model} onChange={(v) => handleChange('normalization_model', v)}
-                  endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat"
-                  placeholder="Default (from global settings)" />
-              </SettingsField>
+              <>
+                <SettingsField label={<>Normalization Model {globalHint('normalization_model')}</>} description="LLM endpoint for normalization. Empty = use global.">
+                  <EndpointSelect value={form.normalization_model} onChange={(v) => handleChange('normalization_model', v)}
+                    endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat"
+                    placeholder="Inherit from global settings" />
+                </SettingsField>
+                <SettingsField label="Intent Split" description="Runs before Question Normalization to isolate the latest intent when a conversation switches topics. Only active while Question Normalization is on.">
+                  <ToggleSwitch checked={form.intent_split_enabled}
+                    onChange={(v) => handleChange('intent_split_enabled', v)} />
+                </SettingsField>
+                {form.intent_split_enabled && (
+                  <SettingsField label={<>Intent Split Model {globalHint('intent_split_model')}</>} description="LLM endpoint for intent split. Empty = use global.">
+                    <EndpointSelect value={form.intent_split_model} onChange={(v) => handleChange('intent_split_model', v)}
+                      endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat"
+                      placeholder="Inherit from global settings" />
+                  </SettingsField>
+                )}
+              </>
             )}
           </div>
 
@@ -204,10 +246,10 @@ export default function GatewaySettingsTab({ gateway, onUpdate }) {
                 onChange={(v) => handleChange('cache_validation_enabled', v)} />
             </SettingsField>
             {form.cache_validation_enabled && (
-              <SettingsField label="Validation Model" description="LLM endpoint for cache validation">
+              <SettingsField label={<>Validation Model {globalHint('validation_model')}</>} description="LLM endpoint for cache validation. Empty = use global.">
                 <EndpointSelect value={form.validation_model} onChange={(v) => handleChange('validation_model', v)}
                   endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat"
-                  placeholder="Default (from global settings)" />
+                  placeholder="Inherit from global settings" />
               </SettingsField>
             )}
           </div>

--- a/frontend/src/components/playground/PlaygroundPage.jsx
+++ b/frontend/src/components/playground/PlaygroundPage.jsx
@@ -2,10 +2,99 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import axios from 'axios'
 import { api } from '../../services/api'
+import { useRole } from '../../context/RoleContext'
 import PipelineVisualizer from './PipelineVisualizer'
 import { Play, Copy, Check, Loader, ChevronDown, Database, Zap, Plus, X, Trash2 } from 'lucide-react'
 
 const POLL_INTERVAL = 2000
+// Bump whenever the persisted payload shape changes in a non-backward-compatible way.
+// The `:v1` suffix on STORAGE_KEY_PREFIX namespaces the key; `SCHEMA_VERSION` is a
+// second gate so a payload written before a shape change is rejected rather than
+// rendered with stale fields.
+const SCHEMA_VERSION = 1
+const STORAGE_KEY_PREFIX = 'playground_session_v1'
+
+// Scope localStorage by the caller's email so user A's conversation can't
+// restore under user B's login on a shared workstation. `_anon` is used
+// before the role context resolves and for the (rare) unauthenticated path.
+function _storageKeyFor(identity) {
+  const scope = identity ? encodeURIComponent(identity) : '_anon'
+  return `${STORAGE_KEY_PREFIX}:${scope}`
+}
+
+// Monotonic counter for tab ids. `Date.now()` collides when two tabs are
+// created in the same millisecond (rapid clicks, test double-invocation);
+// the counter guarantees uniqueness within a session.
+let _tabIdCounter = 0
+const _nextTabId = () => {
+  _tabIdCounter += 1
+  return `${Date.now()}-${_tabIdCounter}`
+}
+
+// Strip the `result` payload when persisting: it can hold hundreds of rows
+// and quickly blows past localStorage's ~5 MB quota. We keep a small
+// placeholder so the restored UI can hint that results were not persisted.
+function _stripHeavyFields(messages) {
+  if (!Array.isArray(messages)) return []
+  return messages.map(m => {
+    if (!m || !m.result) return m
+    const { columns, row_count, data_array } = m.result
+    const rows = Array.isArray(data_array) ? data_array.length : 0
+    return {
+      ...m,
+      result: null,
+      result_summary: {
+        columns: Array.isArray(columns) ? columns : undefined,
+        row_count: typeof row_count === 'number' ? row_count : rows,
+        dropped: true,
+      },
+    }
+  })
+}
+
+function _loadPersistedSession(identity) {
+  try {
+    const raw = localStorage.getItem(_storageKeyFor(identity))
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    // Refuse payloads from a different schema rather than render with stale fields.
+    if (!parsed || parsed.version !== SCHEMA_VERSION) return null
+    if (!Array.isArray(parsed.tabs) || parsed.tabs.length === 0) return null
+    const tabs = parsed.tabs.map(t => ({
+      id: t.id ?? _nextTabId(),
+      label: t.label || 'Conversation',
+      running: false, // always restart cold
+      messages: Array.isArray(t.messages) ? t.messages.map(m => {
+        const wasRunning = m && m.stage && m.stage !== 'completed' && m.stage !== 'failed'
+        return wasRunning
+          ? { ...m, stage: 'failed', error: m.error || 'Query interrupted — you navigated away before it finished.' }
+          : m
+      }) : [],
+    }))
+    return {
+      tabs,
+      activeTabId: tabs.some(t => t.id === parsed.activeTabId) ? parsed.activeTabId : tabs[0].id,
+      selectedGatewayId: parsed.selectedGatewayId || '',
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('Playground: could not read persisted conversation state from localStorage', e)
+    return null
+  }
+}
+
+// Compute the next free "Conversation N" number given the current tab set.
+// Used to initialize `nextTabNumber` so restored tabs don't collide with
+// labels chosen by the unique-number search in handleNewTab.
+function _nextFreeConversationNumber(tabs) {
+  const used = new Set((tabs || []).map(t => {
+    const m = (t.label || '').match(/^Conversation (\d+)$/)
+    return m ? parseInt(m[1], 10) : 0
+  }))
+  let n = 1
+  while (used.has(n)) n++
+  return n
+}
 
 function ResultTable({ data }) {
   if (!data) return null
@@ -181,6 +270,11 @@ function ChatMessage({ item }) {
                 <ResultTable data={item.result} />
               </div>
             )}
+            {!item.result && item.result_summary?.dropped && (
+              <p className="text-[12px] text-dbx-text-secondary italic">
+                Results not restored after reload ({item.result_summary.row_count ?? 0} row{item.result_summary.row_count === 1 ? '' : 's'}). Re-run the query to see them.
+              </p>
+            )}
           </div>
         )}
 
@@ -202,19 +296,30 @@ function ChatMessage({ item }) {
 
 export default function PlaygroundPage() {
   const { id: routeGatewayId } = useParams()
+  const { identity: userIdentity, loading: roleLoading } = useRole()
 
   const [gateways, setGateways] = useState([])
-  const [selectedGatewayId, setSelectedGatewayId] = useState(routeGatewayId || '')
+  const [selectedGatewayId, setSelectedGatewayId] = useState(() => routeGatewayId || '')
   const [gatewayDropdownOpen, setGatewayDropdownOpen] = useState(false)
   const [loadingGateways, setLoadingGateways] = useState(true)
 
   const [queryText, setQueryText] = useState('')
   const [identity, setIdentity] = useState('')
 
-  // Multi-tab conversation state — ephemeral, no persistence
-  const [tabs, setTabs] = useState(() => [{ id: Date.now(), label: 'Conversation 1', messages: [], running: false }])
+  // Multi-tab conversation state. Persisted to localStorage under a user-scoped
+  // key (see `_storageKeyFor`) so user A's conversation can't restore under
+  // user B's login. Restore is deferred to a useEffect that fires once the role
+  // context resolves — we cannot read the right key synchronously since the
+  // identity isn't known at first render. In-flight queries are marked
+  // 'failed/interrupted' on restore rather than resumed.
+  const [tabs, setTabs] = useState(() => (
+    [{ id: _nextTabId(), label: 'Conversation 1', messages: [], running: false }]
+  ))
   const [activeTabId, setActiveTabId] = useState(() => tabs[0]?.id)
-  const nextTabNumber = useRef(2)
+  // Reconciled against restored tabs so a "Conversation N" label never collides
+  // after a reload. handleNewTab re-checks against live state too; this is the
+  // fallback used when all tabs are closed at once.
+  const nextTabNumber = useRef(1)
 
   // Per-tab polling: Map<tabId, { interval, queryId, stageTimestamps }>
   const pollMapRef = useRef(new Map())
@@ -222,6 +327,15 @@ export default function PlaygroundPage() {
   const messagesEndRef = useRef(null)
   const activeTabIdRef = useRef(activeTabId)
   useEffect(() => { activeTabIdRef.current = activeTabId }, [activeTabId])
+
+  // Restore from localStorage keyed by the current user's identity. Tracks which
+  // identity's data is currently loaded in memory so a same-tab user switch
+  // (A → B) flushes A's state back to A's key *before* hydrating B's — otherwise
+  // the next debounced snapshot would write A's conversation under B's key and
+  // overwrite B's own persisted state. `undefined` means "no identity loaded
+  // yet"; any other value (including empty string for anonymous) is a loaded
+  // identity and flushable.
+  const restoredForIdentityRef = useRef(undefined)
 
   const activeTab = tabs.find(t => t.id === activeTabId) || tabs[0]
   const messages = activeTab?.messages || []
@@ -246,7 +360,7 @@ export default function PlaygroundPage() {
   }, [])
 
   const handleNewTab = () => {
-    const newId = Date.now()
+    const newId = _nextTabId()
     setTabs(prev => {
       // Find the next available number that doesn't clash with any existing tab label
       const usedNumbers = new Set(prev.map(t => {
@@ -273,7 +387,7 @@ export default function PlaygroundPage() {
       const remaining = prev.filter(t => t.id !== tabId)
       if (remaining.length === 0) {
         const num = nextTabNumber.current++
-        const newTab = { id: Date.now(), label: `Conversation ${num}`, messages: [], running: false }
+        const newTab = { id: _nextTabId(), label: `Conversation ${num}`, messages: [], running: false }
         setActiveTabId(newTab.id)
         return [newTab]
       }
@@ -297,6 +411,13 @@ export default function PlaygroundPage() {
         setGateways(list)
         if (routeGatewayId && list.some(g => g.id === routeGatewayId)) {
           setSelectedGatewayId(routeGatewayId)
+          return
+        }
+        // Drop a persisted selectedGatewayId if the gateway no longer exists
+        // (deleted while the user was away) — otherwise the dropdown shows
+        // "Select a gateway" with no explanation and submit stays disabled.
+        if (selectedGatewayId && !list.some(g => g.id === selectedGatewayId)) {
+          setSelectedGatewayId(list.length > 0 ? list[0].id : '')
         } else if (!selectedGatewayId && list.length > 0) {
           setSelectedGatewayId(list[0].id)
         }
@@ -325,6 +446,136 @@ export default function PlaygroundPage() {
       pollMapRef.current.clear()
     }
   }, [])
+
+  // Persist conversation state to localStorage so it survives navigation /
+  // reloads. running flags are not persisted — on restore they default to
+  // false and any in-flight messages are marked 'failed'.
+  //
+  // Two persistence paths:
+  //   1. Debounced write while idle (any-tab-not-running). Polling updates the
+  //      tab state every ~2s and we don't want to JSON.stringify every tab on
+  //      every poll, so we skip the debounced write while any tab is running
+  //      and rely on path #2 to capture unmount-during-poll.
+  //   2. Synchronous flush on unmount, route-navigation (visibilitychange +
+  //      pagehide). This runs even while polling, so a user who submits a
+  //      query and navigates away mid-flight still gets their messages
+  //      persisted — the restore path will then mark them 'interrupted'.
+  const anyTabRunning = tabs.some(t => t.running)
+  // Flipped to true on the first localStorage write failure (quota exceeded,
+  // storage disabled by the browser, private-mode restrictions). Surfaces a
+  // one-time dismissible banner so the user knows conversations won't survive
+  // navigation — otherwise they'd silently lose state on the next route change.
+  const [persistFailed, setPersistFailed] = useState(false)
+  const persistWarnedRef = useRef(false)
+
+  // latestSnapshotRef mirrors the current state synchronously so the
+  // lifecycle handler (which sees the closure's snapshot at registration
+  // time, not at fire time) can read the latest without re-registering on
+  // every state change.
+  const latestSnapshotRef = useRef(null)
+  latestSnapshotRef.current = { tabs, activeTabId, selectedGatewayId }
+
+  // Write the current in-memory snapshot under the key scoped to `identity`.
+  // Exposed as a parameterized helper so the identity-change handler can flush
+  // the *previous* user's state to *their* key before hydrating the new user.
+  const writeSnapshotForIdentity = useCallback((identity) => {
+    // Skip writes until we've had a chance to restore — otherwise the initial
+    // empty-tab state would clobber a user's existing persisted conversation
+    // before the restore effect runs.
+    if (restoredForIdentityRef.current === undefined) return
+    const snap = latestSnapshotRef.current
+    if (!snap) return
+    try {
+      const payload = {
+        version: SCHEMA_VERSION,
+        tabs: snap.tabs.map(t => ({
+          id: t.id,
+          label: t.label,
+          messages: _stripHeavyFields(t.messages),
+        })),
+        activeTabId: snap.activeTabId,
+        selectedGatewayId: snap.selectedGatewayId,
+      }
+      localStorage.setItem(_storageKeyFor(identity), JSON.stringify(payload))
+    } catch (e) {
+      if (!persistWarnedRef.current) {
+        persistWarnedRef.current = true
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Playground: could not persist conversation state to localStorage. ' +
+          'Conversations will not survive navigation/reload in this session.',
+          e
+        )
+        setPersistFailed(true)
+      }
+    }
+  }, [])
+
+  // Default path: always write under the identity we last restored for — not
+  // `userIdentity` directly — so a transition from A → B can't re-key A's
+  // still-in-memory state under B.
+  const writeSnapshot = useCallback(() => {
+    writeSnapshotForIdentity(restoredForIdentityRef.current)
+  }, [writeSnapshotForIdentity])
+
+  // Identity-aware hydrate. Runs on first resolve of `userIdentity` and on
+  // any subsequent change (e.g. same tab, different login on a shared
+  // workstation). The first branch flushes the outgoing user's in-memory
+  // state to *their* key before loading the new user's snapshot, so user B
+  // never sees user A's conversation and A's persisted state is preserved.
+  useEffect(() => {
+    if (roleLoading) return
+    if (restoredForIdentityRef.current === userIdentity) return
+
+    // Flush outgoing identity's state before swapping. Skipped on initial
+    // hydrate (ref === undefined) because there's no prior identity to flush to.
+    if (restoredForIdentityRef.current !== undefined) {
+      writeSnapshotForIdentity(restoredForIdentityRef.current)
+    }
+
+    restoredForIdentityRef.current = userIdentity
+    const persisted = _loadPersistedSession(userIdentity)
+    if (persisted) {
+      setTabs(persisted.tabs)
+      setActiveTabId(persisted.activeTabId)
+      if (!routeGatewayId && persisted.selectedGatewayId) {
+        setSelectedGatewayId(persisted.selectedGatewayId)
+      }
+      nextTabNumber.current = _nextFreeConversationNumber(persisted.tabs)
+    } else {
+      // No snapshot for the incoming user — reset to a fresh blank conversation
+      // so user A's tabs don't linger on screen after user B logs in.
+      const freshId = _nextTabId()
+      setTabs([{ id: freshId, label: 'Conversation 1', messages: [], running: false }])
+      setActiveTabId(freshId)
+      if (!routeGatewayId) setSelectedGatewayId('')
+      nextTabNumber.current = 2
+    }
+  }, [roleLoading, userIdentity, routeGatewayId, writeSnapshotForIdentity])
+
+  useEffect(() => {
+    if (anyTabRunning) return
+    const handle = setTimeout(writeSnapshot, 1500)
+    return () => clearTimeout(handle)
+  }, [tabs, activeTabId, selectedGatewayId, anyTabRunning, writeSnapshot])
+
+  useEffect(() => {
+    // Flush on tab hide (user switches tabs / minimizes) and on pagehide
+    // (works for Safari where visibilitychange isn't always fired on unload).
+    // Also flush on unmount — covers client-side route navigation where the
+    // page itself stays alive but the component goes away.
+    const onHide = () => {
+      if (document.visibilityState === 'hidden') writeSnapshot()
+    }
+    const onPageHide = () => writeSnapshot()
+    document.addEventListener('visibilitychange', onHide)
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      document.removeEventListener('visibilitychange', onHide)
+      window.removeEventListener('pagehide', onPageHide)
+      writeSnapshot()
+    }
+  }, [writeSnapshot])
 
   const selectedGateway = gateways.find(g => g.id === selectedGatewayId)
 
@@ -546,6 +797,21 @@ export default function PlaygroundPage() {
           )}
         </div>
       </div>
+
+      {persistFailed && (
+        <div className="flex items-center justify-between gap-2 px-4 py-2 bg-amber-50 border-b border-amber-200 text-[12px] text-amber-900 flex-shrink-0">
+          <span>
+            Conversation persistence is off — browser storage is full or blocked. Your active conversation won't survive navigation or reload.
+          </span>
+          <button
+            onClick={() => setPersistFailed(false)}
+            className="flex-shrink-0 w-5 h-5 rounded hover:bg-dbx-neutral-hover flex items-center justify-center"
+            title="Dismiss"
+          >
+            <X size={12} className="text-dbx-text-secondary" />
+          </button>
+        </div>
+      )}
 
       {/* Chat messages area */}
       <div className="flex-1 overflow-auto px-6 py-4 space-y-6">

--- a/frontend/src/components/settings/SettingsPage.jsx
+++ b/frontend/src/components/settings/SettingsPage.jsx
@@ -225,6 +225,7 @@ export default function SettingsPage() {
     similarity_threshold: '0.92', cache_ttl_value: '24', cache_ttl_unit: 'hours',
     max_queries_per_minute: '5', question_normalization_enabled: true, normalization_model: '',
     cache_validation_enabled: true, validation_model: '',
+    intent_split_enabled: true, intent_split_model: '',
     embedding_provider: 'databricks', databricks_embedding_endpoint: 'databricks-gte-large-en',
     shared_cache: true,
   })
@@ -263,6 +264,8 @@ export default function SettingsPage() {
           normalization_model: server.normalization_model || '',
           cache_validation_enabled: server.cache_validation_enabled !== false,
           validation_model: server.validation_model || '',
+          intent_split_enabled: server.intent_split_enabled !== false,
+          intent_split_model: server.intent_split_model || '',
           embedding_provider: server.embedding_provider || 'databricks',
           databricks_embedding_endpoint: server.databricks_embedding_endpoint || 'databricks-gte-large-en',
           shared_cache: server.shared_cache !== false,
@@ -391,15 +394,20 @@ export default function SettingsPage() {
     const c = configRef.current
     setSaveStatus('saving')
     try {
+      // Preserve user-set 0 (valid "match everything" / "block all traffic");
+      // NaN (blank input) falls through to the undefined backend default.
+      const threshold = parseFloat(c.similarity_threshold)
+      const qpm = parseInt(c.max_queries_per_minute)
       const payload = {
-        storage_backend: 'pgvector',
-        similarity_threshold: parseFloat(c.similarity_threshold) || 0.92,
-        max_queries_per_minute: parseInt(c.max_queries_per_minute) || 5,
+        similarity_threshold: Number.isFinite(threshold) ? threshold : undefined,
+        max_queries_per_minute: Number.isFinite(qpm) ? qpm : undefined,
         cache_ttl_seconds: ttlToSeconds(c.cache_ttl_value, c.cache_ttl_unit),
         question_normalization_enabled: c.question_normalization_enabled,
-        normalization_model: c.normalization_model || undefined,
+        normalization_model: c.normalization_model ?? '',
         cache_validation_enabled: c.cache_validation_enabled,
-        validation_model: c.validation_model || undefined,
+        validation_model: c.validation_model ?? '',
+        intent_split_enabled: c.intent_split_enabled,
+        intent_split_model: c.intent_split_model ?? '',
         embedding_provider: c.embedding_provider,
         databricks_embedding_endpoint: c.databricks_embedding_endpoint,
         shared_cache: c.shared_cache,
@@ -609,6 +617,13 @@ export default function SettingsPage() {
             </FieldRowStacked>
           </div>
 
+          {/* ── Gateway Defaults banner ── */}
+          <div className="mb-4 px-4 py-3 rounded bg-dbx-neutral-hover border border-dbx-border text-[12px] text-dbx-text-secondary">
+            These values are the <strong className="text-dbx-text">defaults for newly created gateways</strong>, and the
+            runtime fallback when a gateway leaves a field unset. Each gateway can override any of these in its own Settings tab.
+            <span className="block mt-1">Saved to Lakebase (<code className="text-[11px]">global_settings</code>) so changes survive redeployments.</span>
+          </div>
+
           {/* ── Cache ── */}
           <div ref={el => sectionRefs.current['cache'] = el} className="mb-10">
             <h3 className="text-[18px] font-semibold text-dbx-text leading-[24px] mb-2">Cache</h3>
@@ -797,8 +812,23 @@ export default function SettingsPage() {
             {config.question_normalization_enabled && (
               <FieldRow label="Normalization Model" description="LLM endpoint used for question normalization">
                 <EndpointSelect value={config.normalization_model} onChange={(v) => handleChange('normalization_model', v)}
-                  endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat" placeholder="Default (workspace default)" />
+                  endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat" placeholder="databricks-llama-4-maverick (default)" />
               </FieldRow>
+            )}
+
+            {config.question_normalization_enabled && (
+              <>
+                <FieldRow label="Intent Split" description="Runs before Question Normalization to isolate the latest intent in multi-turn conversations. Only active while Question Normalization is on.">
+                  <ToggleSwitch checked={config.intent_split_enabled}
+                    onChange={(v) => handleChange('intent_split_enabled', v)} />
+                </FieldRow>
+                {config.intent_split_enabled && (
+                  <FieldRow label="Intent Split Model" description="LLM endpoint used for intent splitting">
+                    <EndpointSelect value={config.intent_split_model} onChange={(v) => handleChange('intent_split_model', v)}
+                      endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat" placeholder="databricks-llama-4-maverick (default)" />
+                  </FieldRow>
+                )}
+              </>
             )}
 
             <FieldRow label="Cache Validation" description="LLM validates cached results are relevant before returning">
@@ -809,7 +839,7 @@ export default function SettingsPage() {
             {config.cache_validation_enabled && (
               <FieldRow label="Validation Model" description="LLM endpoint used for cache validation">
                 <EndpointSelect value={config.validation_model} onChange={(v) => handleChange('validation_model', v)}
-                  endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat" placeholder="Default (workspace default)" />
+                  endpoints={endpoints} loading={endpointsLoading} filterTask="llm/v1/chat" placeholder="databricks-llama-4-maverick (default)" />
               </FieldRow>
             )}
 


### PR DESCRIPTION
## Summary

Closes #26. Fixes all five settings / conversation-state issues end-to-end:

- **Global settings survive redeploys** — moved from `/tmp/genie_cache_config.json` to a Lakebase `global_settings` JSONB table, hydrated at FastAPI lifespan startup. `lakebase_service_token` stays in-memory only; the sensitive-key guard is now boundary-matched (no more false positives on `patch_interval` / `path_prefix`).
- **Gateway create no longer hardcodes defaults** — `_build_gateway_config_from_body` stores `NULL` for unset fields and `_build_runtime_settings` resolves them dynamically via `_coalesce` against the current global. Changing the global threshold now actually propagates to existing gateways that left the field unset.
- **LLM model dropdowns are wired end-to-end** — new `normalization_model` / `validation_model` / `intent_split_model` columns on `gateway_configs`, surfaced through `RuntimeSettings`, consumed by each service's `_get_workspace_client()`. Empty string normalizes to `NULL` so "clear override" actually falls back to the global, then to the module default.
- **`or` falsy-fallback bug fixed** — all numeric/boolean fallbacks use `is not None`, so `similarity_threshold=0` ("match everything") and `max_queries_per_minute=0` ("block all traffic") are preserved instead of silently reverting to the base default.
- **Playground conversation state persists** — user-scoped `localStorage` with `SCHEMA_VERSION` gating, heavy `result` payload stripped, in-flight queries marked `failed/interrupted` on restore, flushes on `visibilitychange` / `pagehide` / unmount, one-time user-facing banner if storage is quota-blocked.
- **UI clarifies precedence** — Settings page banner ("defaults for new gateways, runtime fallback when a gateway leaves a field unset"); per-gateway Settings tab shows the current global value next to each overridable field.

Also adds `DELETE /settings/{key}` (allowlisted via `SettingsUpdateRequest.model_fields` with a boot-time drift assert) and a new `intent_split_enabled` toggle.

## Test plan

- [x] 75 new unit tests covering: JSONB type-coercion, DB-first ordering invariant for `update_overrides` / `delete_override`, sensitive-key boundary regex, clearable-model-field semantics, `RuntimeSettings` numeric/model fallback, gateway-create None-in/None-out, per-service endpoint resolution.
- [ ] Deploy to dev workspace — verify settings persist across a redeploy (save, redeploy, reload Settings page, values still present).
- [ ] Create a gateway with default settings; change global `similarity_threshold` to `0.85`; confirm the new gateway picks up `0.85` on next query (runtime resolution).
- [ ] Per-gateway: set `normalization_model` to a custom endpoint, confirm that endpoint is used; clear it (empty string), confirm fallback to global.
- [ ] Playground: submit a query, navigate to Gateways, navigate back — conversation + tabs restored; running query shows "interrupted" message.
- [ ] Playground: sign out of user A, sign in as user B on the same browser — B sees a clean conversation, A's state preserved under A's key.