### PR TITLE
chore: stop tracking .claude/ worktrees as gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ test-evidence/
 
 # Claude Code
 CLAUDE.md
+.claude/
 
 # Auto-generated version file (written by install.sh at deploy time)
 backend/app/_version.py


### PR DESCRIPTION
## Summary

A claude-code worktree at \`.claude/worktrees/fix-lakebase-schema\` got committed as a gitlink (mode 160000) — it now shows up in the repo root on GitHub as a ghost submodule pointing to the \`v1.4.0\` commit.

- Remove the gitlink entry from the index (doesn't touch any working tree).
- Add \`.claude/\` to \`.gitignore\` so future worktrees/settings stay local-only.

## Test plan
- [ ] \`git ls-tree -r HEAD .claude/\` → empty after merge.
- [ ] \`.claude/worktrees/\` no longer appears at the top of the repo file listing on GitHub.

Co-authored-by: Isaac