### PR TITLE
feat(ui): show app version in sidebar footer

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -70,12 +70,14 @@ experimental:
 workspace:
   root_path: /Workspace/apps/.bundle/${bundle.name}/${bundle.target}
 
-# .gitignore excludes `frontend/dist/` (it's a build output), but the deployed
-# app serves the bundled frontend from there. Override the gitignore for
-# bundle sync so the predeploy hook's build outputs are uploaded.
+# .gitignore excludes the predeploy build outputs (frontend/dist/ and the
+# auto-generated backend/app/_version.py). The deployed app needs both:
+# the SPA bundle to serve, and the version stamp for /api/version + the
+# sidebar version indicator. Override the gitignore for bundle sync.
 sync:
   include:
     - frontend/dist/**
+    - backend/app/_version.py
 
 variables:
   app_name:

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { Layers, Play, Code2, Plug, Bug, Route as RouteIcon } from 'lucide-react'
+import { api } from '../../services/api'
 
 const mainNavItems = [
   { to: '/', icon: Layers, label: 'Gateways', end: true },
@@ -37,6 +39,14 @@ function NavItem({ to, icon: Icon, label, end }) {
 }
 
 export default function Sidebar() {
+  const [version, setVersion] = useState(null)
+
+  useEffect(() => {
+    api.getVersion()
+      .then((v) => setVersion(v?.version || null))
+      .catch(() => setVersion(null))
+  }, [])
+
   return (
     <aside className="w-[200px] bg-dbx-sidebar flex flex-col p-2 h-full">
       <nav className="flex flex-col gap-0.5 flex-1">
@@ -51,6 +61,14 @@ export default function Sidebar() {
           <NavItem key={item.to} {...item} />
         ))}
       </nav>
+      {version && (
+        <div
+          className="px-3 pt-2 pb-1 text-[11px] text-dbx-text-secondary font-mono text-center"
+          title="App version (git describe)"
+        >
+          {version}
+        </div>
+      )}
     </aside>
   )
 }


### PR DESCRIPTION
## Summary
- Version (from `/api/version`, written by `scripts/build.sh` as `git describe --tags --always --dirty`) is now shown in the sidebar footer, visible on every page.
- Previously visible only at the bottom of the Settings page.

## Test plan
- [ ] Sidebar footer shows the deployed version (e.g. `v1.7.0` right at the tag, `v1.7.0-3-gabc1234` once commits land on top).
- [ ] Title tooltip on hover reads "App version (git describe)".
- [ ] Empty/failed `/api/version` leaves the footer hidden (no broken layout).